### PR TITLE
Some fixes for vim theme

### DIFF
--- a/Vim/Tomorrow-Night.vim
+++ b/Vim/Tomorrow-Night.vim
@@ -8,7 +8,7 @@ let g:colors_name = "Tomorrow-Night"
 let s:foreground = "c5c8c6"
 let s:background = "1d1f21"
 let s:selection = "373b41"
-let s:line = "282a2e"
+let s:line = "35373c"
 let s:comment = "969896"
 let s:red = "cc6666"
 let s:orange = "de935f"
@@ -234,10 +234,10 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("LineNr", s:foreground, "", "")
 	call <SID>X("NonText", s:selection, "", "")
 	call <SID>X("SpecialKey", s:selection, "", "")
-	call <SID>X("Search", s:foreground, s:selection, "")
+	call <SID>X("Search", s:yellow, s:selection, "reverse")
 	call <SID>X("StatusLine", s:foreground, s:background, "reverse")
 	call <SID>X("StatusLineNC", s:foreground, s:background, "reverse")
-	call <SID>X("Visual", s:foreground, s:selection, "")
+	call <SID>X("Visual", s:foreground, s:selection, "reverse")
 	call <SID>X("Directory", s:blue, "", "")
 	call <SID>X("ModeMsg", s:green, "", "")
     call <SID>X("MoreMsg", s:green, "", "")
@@ -245,6 +245,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("WarningMsg", s:red, "", "")
 	if version >= 700
 		call <SID>X("CursorLine", "", s:line, "none")
+		call <SID>X("CursorColumn", "", s:line, "none")
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
@@ -266,6 +267,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Operator", s:foreground, "", "none")
 	call <SID>X("Type", s:blue, "", "none")
 	call <SID>X("Define", s:purple, "", "none")
+	call <SID>X("Include", s:blue, "", "") 
 	"call <SID>X("Ignore", "666666", "", "")
 	
 	" Vim Highlighting
@@ -283,7 +285,8 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("rubySymbol", s:green, "", "")	
 	call <SID>X("rubyConstant", s:yellow, "", "")	
 	call <SID>X("rubyAttribute", s:blue, "", "")	
-	call <SID>X("rubyLocalVariableOrMethod", s:blue, "", "")	
+	call <SID>X("rubyInclude", s:blue, "", "") 
+	call <SID>X("rubyLocalVariableOrMethod", s:orange, "", "")	
 	call <SID>X("rubyCurlyBlock", s:orange, "", "") 
 
 	" Delete Functions


### PR DESCRIPTION
Some small vim fixes.

Too bad the terminal only supports 256 colors... This way it's not possible to make the vim version completely compatible.
