### PR TITLE
For vim, set the colorscheme name after the syntax reset

### DIFF
--- a/Vim/Tomorrow-Night-Blue.vim
+++ b/Vim/Tomorrow-Night-Blue.vim
@@ -3,8 +3,6 @@
 "
 " Hex colour conversion functions borrowed from the theme "Desert256""
 
-let g:colors_name = "Tomorrow-Night-Blue"
-
 " Default GUI Colours
 let s:foreground = "ffffff"
 let s:background = "002451"
@@ -21,6 +19,8 @@ let s:purple = "ebbbff"
 set background=dark
 hi clear
 syntax reset
+
+let g:colors_name = "Tomorrow-Night-Blue"
 
 if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	" Returns an approximate grey index for the given grey level

--- a/Vim/Tomorrow-Night-Eighties.vim
+++ b/Vim/Tomorrow-Night-Eighties.vim
@@ -3,8 +3,6 @@
 "
 " Hex colour conversion functions borrowed from the theme "Desert256""
 
-let g:colors_name = "Tomorrow-Night-Eighties"
-
 " Default GUI Colours
 let s:foreground = "cccccc"
 let s:background = "2d2d2d"
@@ -21,6 +19,8 @@ let s:purple = "cc99cc"
 set background=dark
 hi clear
 syntax reset
+
+let g:colors_name = "Tomorrow-Night-Eighties"
 
 if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	" Returns an approximate grey index for the given grey level

--- a/Vim/Tomorrow-Night.vim
+++ b/Vim/Tomorrow-Night.vim
@@ -3,8 +3,6 @@
 "
 " Hex colour conversion functions borrowed from the theme "Desert256""
 
-let g:colors_name = "Tomorrow-Night"
-
 " Default GUI Colours
 let s:foreground = "c5c8c6"
 let s:background = "1d1f21"
@@ -28,6 +26,8 @@ end
 set background=dark
 hi clear
 syntax reset
+
+let g:colors_name = "Tomorrow-Night"
 
 if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	" Returns an approximate grey index for the given grey level

--- a/Vim/Tomorrow.vim
+++ b/Vim/Tomorrow.vim
@@ -3,8 +3,6 @@
 "
 " Hex colour conversion functions borrowed from the theme "Desert256""
 
-let g:colors_name = "Tomorrow"
-
 " Default GUI Colours
 let s:foreground = "4d4d4c"
 let s:background = "ffffff"
@@ -21,6 +19,8 @@ let s:purple = "8959a8"
 set background=light
 hi clear
 syntax reset
+
+let g:colors_name = "Tomorrow"
 
 if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	" Returns an approximate grey index for the given grey level


### PR DESCRIPTION
For some reason it doesn't work for me in Macvim otherwise.
