### PR TITLE
Vim theme adjustments

### DIFF
--- a/Vim/Tomorrow-Night-Bright.vim
+++ b/Vim/Tomorrow-Night-Bright.vim
@@ -6,7 +6,7 @@
 " Default GUI Colours
 let s:foreground = "eaeaea"
 let s:background = "000000"
-let s:selection = "424242"
+let s:selection = "562D56"
 let s:line = "2a2a2a"
 let s:comment = "969896"
 let s:search= "daa520"


### PR DESCRIPTION
This is a matter of preference but I've adjusted several vim color to be easier to see:
- Changes 'Search' background to gold. It's hard to the see a white cursor on a yellow background.
- Changes line numbers to be the same as comments. I prefer for line numbers to take a back seat to code.
- Changes selection to purple. It's difficult to see gray at different brightness levels.
