### PR TITLE
Adds textmate syntax highlighting for meta.tag and declaration.tag

### DIFF
--- a/TextMate/Tomorrow-Night-Blue.tmTheme
+++ b/TextMate/Tomorrow-Night-Blue.tmTheme
@@ -53,7 +53,7 @@
 			<key>name</key>
 			<string>Variable, String Link, Regular Expression, Tag Name</string>
 			<key>scope</key>
-			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name</string>
+			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name, meta.tag, declaration.tag</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/TextMate/Tomorrow-Night-Bright.tmTheme
+++ b/TextMate/Tomorrow-Night-Bright.tmTheme
@@ -53,7 +53,7 @@
 			<key>name</key>
 			<string>Variable, String Link, Regular Expression, Tag Name</string>
 			<key>scope</key>
-			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name</string>
+			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name, meta.tag, declaration.tag</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/TextMate/Tomorrow-Night-Eighties.tmTheme
+++ b/TextMate/Tomorrow-Night-Eighties.tmTheme
@@ -53,7 +53,7 @@
 			<key>name</key>
 			<string>Variable, String Link, Tag Name</string>
 			<key>scope</key>
-			<string>variable, support.other.variable, string.other.link, entity.name.tag, entity.other.attribute-name</string>
+			<string>variable, support.other.variable, string.other.link, entity.name.tag, entity.other.attribute-name, meta.tag, declaration.tag</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/TextMate/Tomorrow-Night.tmTheme
+++ b/TextMate/Tomorrow-Night.tmTheme
@@ -53,7 +53,7 @@
 			<key>name</key>
 			<string>Variable, String Link, Regular Expression, Tag Name</string>
 			<key>scope</key>
-			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name</string>
+			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name, meta.tag, declaration.tag</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/TextMate/Tomorrow.tmTheme
+++ b/TextMate/Tomorrow.tmTheme
@@ -53,7 +53,7 @@
 			<key>name</key>
 			<string>Variable, String Link, Regular Expression, Tag Name</string>
 			<key>scope</key>
-			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name</string>
+			<string>variable, support.other.variable, string.other.link, string.regexp, entity.name.tag, entity.other.attribute-name, meta.tag, declaration.tag</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
Great theme so thanks for putting it together. I use the haml syntax highlighter and it uses declaration.tag and meta.tag for coloring various tags in the haml templates. I was sad to discover they were uncolored with this theme. Added syntax highlighting for these tags leveraging the `entity.name.tag` color scheme already supported. Hope you can pull this in as this is the only issue I see with the theme so far.
