### PR TITLE
ColorColumn Highlighting

### DIFF
--- a/Vim/Tomorrow-Night-Blue.vim
+++ b/Vim/Tomorrow-Night-Blue.vim
@@ -252,6 +252,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
+  if version >= 703
+		call <SID>X("ColorColumn", "", s:line, "none")
+	end
 
 	" Standard Highlighting
 	call <SID>X("Comment", s:comment, "", "")

--- a/Vim/Tomorrow-Night-Bright.vim
+++ b/Vim/Tomorrow-Night-Bright.vim
@@ -252,6 +252,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
+  if version >= 703
+		call <SID>X("ColorColumn", "", s:line, "none")
+	end
 
 	" Standard Highlighting
 	call <SID>X("Comment", s:comment, "", "")

--- a/Vim/Tomorrow-Night-Eighties.vim
+++ b/Vim/Tomorrow-Night-Eighties.vim
@@ -252,6 +252,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
+  if version >= 703
+		call <SID>X("ColorColumn", "", s:line, "none")
+	end
 
 	" Standard Highlighting
 	call <SID>X("Comment", s:comment, "", "")

--- a/Vim/Tomorrow-Night.vim
+++ b/Vim/Tomorrow-Night.vim
@@ -259,6 +259,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
+  if version >= 703
+		call <SID>X("ColorColumn", "", s:line, "none")
+	end
 
 	" Standard Highlighting
 	call <SID>X("Comment", s:comment, "", "")

--- a/Vim/Tomorrow.vim
+++ b/Vim/Tomorrow.vim
@@ -251,6 +251,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 		call <SID>X("PMenu", s:foreground, s:selection, "none")
 		call <SID>X("PMenuSel", s:foreground, s:selection, "reverse")
 	end
+  if version >= 703
+		call <SID>X("ColorColumn", "", s:line, "none")
+	end
 
 	" Standard Highlighting
 	call <SID>X("Comment", s:comment, "", "")


### PR DESCRIPTION
Set ColorColumn to s:line for Vim 7.3+
