### PR TITLE
Color Correction for Notepad++ (plus an additional theme)

### DIFF
--- a/notepad++/tomorrow_night.xml
+++ b/notepad++/tomorrow_night.xml
@@ -1,0 +1,759 @@
+<!--//
+
+Tomorrow Night
+Copyright (c) 2008 Fabio Zendhi Nagao <http://zend.lojcomm.com.br/>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+Requirements:
+    * This style is based on DejaVu fonts <http://dejavu.sourceforge.net/wiki/index.php/Main_Page>.
+    * Notepad++, of course.
+
+Installation:
+    Copy this file to %APPDATA%\Notepad++\ (start->run, type: %APPDATA%\Notepad++, hit Enter) and
+    %PROGRAMFILES%\Notepad++\ (start->run, type: %PROGRAMFILES%\Notepad++, hit Enter)
+
+About:
+    This styler has been built by Textmate theme to Notepad++ styler <http://framework.lojcomm.com.br/tmTheme2nppStyler/>
+
+Credits:
+    Thanks for the original Textmate theme author.
+    Thanks for Fabio Zendhi Nagao for the tmTheme2nppStyler.
+    Thanks for the user for the tmTheme source.
+
+//-->
+<?xml version="1.0" encoding="Windows-1252" ?>
+<NotepadPlus>
+    <LexerStyles>
+        <LexerType name="c" desc="C" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPEWORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="cpp" desc="C++" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="java" desc="Java" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="cs" desc="C#" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="rc" desc="RC" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="tcl" desc="TCL" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="objc" desc="Objective-C" ext="m">
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2">synthesize</WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="8841D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">NSString NSObject NSView NSWindow NSArray NSNumber NSUserDefaults NSNotification NSNotificationCenter CALayer CGColorRef NSEvent NSPoint NSSize NSRect CGPoint CGSize CGRect CGFloat unichar NSSet NSDictionary NSMutableString </WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="sql" desc="SQL" ext="">
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="html" desc="HTML" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAG" styleID="1" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="php" desc="php" ext="">
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="119" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="121" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="javascript" desc="Javascript" ext="">
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="46" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="asp" desc="asp" ext="asp">
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="84" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASPSYBOL" styleID="15" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="xml" desc="XML" ext="">
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAG" styleID="1" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="ini" desc="ini file" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="props" desc="Properties file" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="diff" desc="DIFF" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="F0C674" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="nfo" desc="Dos Style" ext="">
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="C5C8C6" bgColor="1D1F21" />
+        </LexerType>
+        <LexerType name="makefile" desc="Makefile" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="vb" desc="VB / VBS" ext="">
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="3" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATE" styleID="8" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="css" desc="CSS" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAG" styleID="1" fgColor="CC6666" bgColor="1D1F21" fontName="Batang" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ID" styleID="10" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="pascal" desc="Pascal" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="perl" desc="Perl" ext="">
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="17" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FF0000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="python" desc="Python" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="3" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="B9CA48" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="B9CA48" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F0C674" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="12" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="batch" desc="Batch" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HIDE SYBOL" styleID="4" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="lua" desc="Lua" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+        </LexerType>
+        <LexerType name="tex" desc="TeX" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="nsis" desc="NSIS" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="actionscript" desc="ActionScript" ext="">
+            <!--
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            -->
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="bash" desc="bash" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="5" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="fortran" desc="Fortran" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="3" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="lisp" desc="LISP" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="asm" desc="Assembler" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="3" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+        </LexerType>
+        <LexerType name="ruby" desc="Ruby" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="F0C674" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="postscript" desc="Postscript" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="vhdl" desc="VHDL" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="4" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+        </LexerType>
+        <LexerType name="smalltalk" desc="Smalltalk" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="1" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="caml" desc="Caml" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="11" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="verilog" desc="Verilog" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="kix" desc="KiXtart" ext="">
+            <!--
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="1D1F21" fontName="" fontStyle="" fontSize="10" />
+        -->
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="2" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="autoit" desc="autoIt" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="ada" desc="ADA" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="7" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="matlab" desc="Matlab" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="haskell" desc="Haskell" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="4" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="inno" desc="InnoSetup" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="cmake" desc="CMakeFile" ext="cmake">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        </LexerType>
+        <LexerType name="searchResult" desc="Search result" ext="">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C5C8C6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELECTED LINE" styleID="6" fgColor="D5D8D6" bgColor="282A2E" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEARDER" styleID="1" fgColor="B5BD68" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HIT WORD" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD1" styleID="4" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2">if else for while</WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="5" fgColor="8ABEB7" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">bool long int char</WordsStyle>
+        </LexerType>
+    </LexerStyles>
+    <GlobalStyles>
+        <!-- Attention : Don't modify the name of styleID="0" -->
+        <WidgetStyle name="Global override" styleID="0" fgColor="C5C8C6" bgColor="000000" fontName="Consolas" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Default Style" styleID="32" fgColor="C5C8C6" bgColor="1D1F21" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="F0C674" bgColor="1D1F21" fontName="" fontStyle="1" fontSize="10" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="282A2E" />
+        <WidgetStyle name="Mark colour" styleID="0" fgColor="CC6666" bgColor="F0C674" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="373B41" />
+        <WidgetStyle name="Caret colour" styleID="2069" fgColor="AEAFAD" />
+        <WidgetStyle name="Find Mark Style" styleID="31" fgColor="CC6666" bgColor="F0C674" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Edge colour" styleID="0" fgColor="EEEEEC" />
+        <WidgetStyle name="Line number margin" styleID="33" fgColor="EEEEEC" bgColor="2E3436" fontName="" fontStyle="0" fontSize="8" />
+        <WidgetStyle name="Fold" styleID="0" fgColor="2E3436" bgColor="EEEEEC" />
+        <WidgetStyle name="Fold margin" styleID="0" fgColor="555753" bgColor="2E3436" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="FCAF3E" />
+        <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="888A85" />
+        <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="888A85" />
+        <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="C17D11" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="DE935F" />
+        <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="FCAF3E" />
+        <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="F57900" />
+        <WidgetStyle name="Active tab text" styleID="0" fgColor="2E3436" />
+        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="555753" bgColor="BABDB6" />
+    </GlobalStyles>
+</NotepadPlus>

--- a/notepad++/tomorrow_night_bright.xml
+++ b/notepad++/tomorrow_night_bright.xml
@@ -45,703 +45,703 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPEWORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPEWORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="m">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2">synthesize</WordsStyle>
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="8841D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">NSString NSObject NSView NSWindow NSArray NSNumber NSUserDefaults NSNotification NSNotificationCenter CALayer CGColorRef NSEvent NSPoint NSSize NSRect CGPoint CGSize CGRect CGFloat unichar NSSet NSDictionary NSMutableString </WordsStyle>
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2">synthesize</WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="8841D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">NSString NSObject NSView NSWindow NSArray NSNumber NSUserDefaults NSNotification NSNotificationCenter CALayer CGColorRef NSEvent NSPoint NSSize NSRect CGPoint CGSize CGRect CGFloat unichar NSSet NSDictionary NSMutableString </WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="7" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAG" styleID="1" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="119" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="122" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="119" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="121" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="javascript" desc="Javascript" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="46" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="85" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASPSYBOL" styleID="15" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="84" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASPSYBOL" styleID="15" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="XMLEND" styleID="13" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAG" styleID="1" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="E7C547" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="7AA6DA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="E7C547" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
-            <WordsStyle name="DEFAULT" styleID="32" fgColor="EAEAEA" bgColor="1D1F21" />
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="eaeaea" bgColor="000000" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="WORD" styleID="3" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATE" styleID="8" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="CC6666" bgColor="1D1F21" fontName="Batang" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAG" styleID="1" fgColor="D54E53" bgColor="000000" fontName="Batang" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ID" styleID="10" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="17" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="FF0000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATASECTION" styleID="21" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGSUBST" styleID="18" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="20" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="17" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FF0000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="B9CA48" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="B9CA48" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="E7C547" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="7AA6DA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="12" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="3" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="B9CA48" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="B9CA48" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="E7C547" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="12" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIDE SYBOL" styleID="4" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HIDE SYBOL" styleID="4" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="5" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="LABEL" styleID="7" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="SECTION" styleID="9" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="5" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="3" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="3" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="F0C674" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING Q" styleID="24" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="E7C547" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="12" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B294BB" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="4" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="C397D8" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="1" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="D5D8D6" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="1" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="D5D8D6" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="8" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="11" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="11" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="6" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="1D1F21" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="000000" fontName="" fontStyle="" fontSize="10" />
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="3" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="2" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="81A2BE" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STRING" styleID="7" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="7" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="9" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="7" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="06ABE1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="7AA6DA" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="73EC0F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="6" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING" styleID="4" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="73EC0F" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SECTION" styleID="4" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="E78C45" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING R" styleID="4" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="DE935F" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="969896" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="E78C45" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="EAEAEA" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELECTED LINE" styleID="6" fgColor="D5D8D6" bgColor="343537" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEARDER" styleID="1" fgColor="B9CA4A" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIT WORD" styleID="3" fgColor="CC6666" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD1" styleID="4" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2">if else for while</WordsStyle>
-            <WordsStyle name="KEYWORD2" styleID="5" fgColor="70C0B1" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">bool long int char</WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELECTED LINE" styleID="6" fgColor="D5D8D6" bgColor="2A2A2A" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEARDER" styleID="1" fgColor="B9CA4A" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HIT WORD" styleID="3" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD1" styleID="4" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2">if else for while</WordsStyle>
+            <WordsStyle name="KEYWORD2" styleID="5" fgColor="70C0B1" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">bool long int char</WordsStyle>
         </LexerType>
     </LexerStyles>
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
-        <WidgetStyle name="Global override" styleID="0" fgColor="EAEAEA" bgColor="000000" fontName="Consolas" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Default Style" styleID="32" fgColor="EAEAEA" bgColor="1D1F21" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="1D1F21" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="1D1F21" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Current line background colour" styleID="0" bgColor="343537" />
-        <WidgetStyle name="Mark colour" styleID="0" fgColor="CC0000" bgColor="EDD400" />
-        <WidgetStyle name="Selected text colour" styleID="0" bgColor="4A4C4D" />
+        <WidgetStyle name="Global override" styleID="0" fgColor="eaeaea" bgColor="000000" fontName="Consolas" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Default Style" styleID="32" fgColor="eaeaea" bgColor="000000" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="E7C547" bgColor="000000" fontName="" fontStyle="1" fontSize="10" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="D54E53" bgColor="000000" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Current line background colour" styleID="0" bgColor="2A2A2A" />
+        <WidgetStyle name="Mark colour" styleID="0" fgColor="D54E53" bgColor="E7C547" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="424242" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="AEAFAD" />
-        <WidgetStyle name="Find Mark Style" styleID="31" fgColor="CC0000" bgColor="EDD400" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Find Mark Style" styleID="31" fgColor="D54E53" bgColor="E7C547" fontName="" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="EEEEEC" />
         <WidgetStyle name="Line number margin" styleID="33" fgColor="EEEEEC" bgColor="2E3436" fontName="" fontStyle="0" fontSize="8" />
         <WidgetStyle name="Fold" styleID="0" fgColor="2E3436" bgColor="EEEEEC" />
@@ -750,7 +750,7 @@ Credits:
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="888A85" />
         <WidgetStyle name="Incremental highlight all" styleID="28" bgColor="888A85" />
         <WidgetStyle name="Tags match highlighting" styleID="27" bgColor="C17D11" />
-        <WidgetStyle name="Tags attribute" styleID="26" bgColor="E9B96E" />
+        <WidgetStyle name="Tags attribute" styleID="26" bgColor="E78C45" />
         <WidgetStyle name="Active tab focused indicator" styleID="0" fgColor="FCAF3E" />
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="F57900" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="2E3436" />


### PR DESCRIPTION
Notepad++ theme had a number of custom colors in the 'night-bright' theme as well as colors from both the night and night-bright themes. Separated the theme into two separate files and corrected colors for both themes to match the original swatches of the theme.
