### PR TITLE
updates submodule urls after changing GitHub username

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "TextMate"]
 	path = TextMate
-	url = git://github.com/ChrisKempson/TextMate-Tomorrow-Theme.git
+	url = git://github.com/chriskempson/TextMate-Tomorrow-Theme.git
 [submodule "Vim"]
 	path = Vim
-	url = git://github.com/ChrisKempson/Vim-Tomorrow-Theme.git
+	url = git://github.com/chriskempson/Vim-Tomorrow-Theme.git


### PR DESCRIPTION
After changing your GitHub username from ChrisKempson to chriskempson, it broke all existing remote repository links and git submodule links.

This update will resolve the issue when retrieving submodules from a newly cloned repository.
