### PR TITLE
Added diff markup support to all textmate theme variants

### DIFF
--- a/textmate/Tomorrow-Night-Blue.tmTheme
+++ b/textmate/Tomorrow-Night-Blue.tmTheme
@@ -197,9 +197,7 @@
 			<string>markup.inserted.diff, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#718c00</string>
 			</dict>
 		</dict>
@@ -210,23 +208,36 @@
 			<string>markup.deleted.diff, meta.diff.header.from-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#c82829</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Diff header to file</string>
+			<string>Diff header</string>
 			<key>scope</key>
 			<string>meta.diff.header.from-file, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string>italic</string>
+				<key>foreground</key>
+				<string>#FFFFFF</string>
+				<key>background</key>
+				<string>#4271ae</string>
 			</dict>
 		</dict>		
+		<dict>
+			<key>name</key>
+			<string>Diff range</string>
+			<key>scope</key>
+			<string>meta.diff.range</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#3e999f</string>
+			</dict>
+		</dict>	
 	</array>
 	<key>uuid</key>
 	<string>3F4BB232-3C3A-4396-99C0-06A9573715E9</string>

--- a/textmate/Tomorrow-Night-Bright.tmTheme
+++ b/textmate/Tomorrow-Night-Bright.tmTheme
@@ -197,9 +197,7 @@
 			<string>markup.inserted.diff, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#718c00</string>
 			</dict>
 		</dict>
@@ -210,23 +208,36 @@
 			<string>markup.deleted.diff, meta.diff.header.from-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#c82829</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Diff header to file</string>
+			<string>Diff header</string>
 			<key>scope</key>
 			<string>meta.diff.header.from-file, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string>italic</string>
+				<key>foreground</key>
+				<string>#FFFFFF</string>
+				<key>background</key>
+				<string>#4271ae</string>
 			</dict>
 		</dict>		
+		<dict>
+			<key>name</key>
+			<string>Diff range</string>
+			<key>scope</key>
+			<string>meta.diff.range</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#3e999f</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>33D8C715-AD3A-455B-8DF2-56F708909FFE</string>

--- a/textmate/Tomorrow-Night-Eighties.tmTheme
+++ b/textmate/Tomorrow-Night-Eighties.tmTheme
@@ -197,9 +197,7 @@
 			<string>markup.inserted.diff, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#718c00</string>
 			</dict>
 		</dict>
@@ -210,23 +208,37 @@
 			<string>markup.deleted.diff, meta.diff.header.from-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#c82829</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Diff header to file</string>
+			<string>Diff header</string>
 			<key>scope</key>
 			<string>meta.diff.header.from-file, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
+				<key>foreground</key>
+				<string>#FFFFFF</string>
+				<key>background</key>
+				<string>#4271ae</string>
+			</dict>
+		</dict>		
+		<dict>
+			<key>name</key>
+			<string>Diff range</string>
+			<key>scope</key>
+			<string>meta.diff.range</string>
+			<key>settings</key>
+			<dict>
 				<key>fontStyle</key>
 				<string>italic</string>
+				<key>foreground</key>
+				<string>#3e999f</string>
 			</dict>
-		</dict>	</array>
+		</dict>
+	</array>
 	<key>uuid</key>
 	<string>DE477E5B-BD4D-46B0-BF80-2EA32A2814D5</string>
 </dict>

--- a/textmate/Tomorrow-Night.tmTheme
+++ b/textmate/Tomorrow-Night.tmTheme
@@ -197,9 +197,7 @@
 			<string>markup.inserted.diff, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#718c00</string>
 			</dict>
 		</dict>
@@ -210,23 +208,36 @@
 			<string>markup.deleted.diff, meta.diff.header.from-file</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string></string>
-				<key>background</key>
+				<key>foreground</key>
 				<string>#c82829</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Diff header to file</string>
+			<string>Diff header</string>
 			<key>scope</key>
 			<string>meta.diff.header.from-file, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
+				<key>foreground</key>
+				<string>#FFFFFF</string>
+				<key>background</key>
+				<string>#4271ae</string>
+			</dict>
+		</dict>		
+		<dict>
+			<key>name</key>
+			<string>Diff range</string>
+			<key>scope</key>
+			<string>meta.diff.range</string>
+			<key>settings</key>
+			<dict>
 				<key>fontStyle</key>
 				<string>italic</string>
+				<key>foreground</key>
+				<string>#3e999f</string>
 			</dict>
-		</dict>
+		</dict>		
 	</array>
 	<key>uuid</key>
 	<string>F96223EB-1A60-4617-92F3-D24D4F13DB09</string>

--- a/textmate/Tomorrow.tmTheme
+++ b/textmate/Tomorrow.tmTheme
@@ -189,7 +189,7 @@
 				<key>foreground</key>
 				<string>#FFFFFF</string>
 			</dict>
-		</dict>		
+		</dict>				
 		<dict>
 			<key>name</key>
 			<string>Diff insertion</string>
@@ -214,13 +214,28 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Diff header to file</string>
+			<string>Diff header</string>
 			<key>scope</key>
 			<string>meta.diff.header.from-file, meta.diff.header.to-file</string>
 			<key>settings</key>
 			<dict>
+				<key>foreground</key>
+				<string>#FFFFFF</string>
+				<key>background</key>
+				<string>#4271ae</string>
+			</dict>
+		</dict>		
+		<dict>
+			<key>name</key>
+			<string>Diff range</string>
+			<key>scope</key>
+			<string>meta.diff.range</string>
+			<key>settings</key>
+			<dict>
 				<key>fontStyle</key>
 				<string>italic</string>
+				<key>foreground</key>
+				<string>#3e999f</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
I added bits to all the themes so `git diff | mate` or `diff x y | mate` gets some colour highlighting.

Screenshot here: http://i.imgur.com/FInj2.png

I went with the background color instead of the foreground color because was what I was used to from other  Textmate themes, but optionally you could change the foreground color instead (screenshot: http://i.imgur.com/cyh65.png). I couldn't decide which is better so I went with the old style. Open to comments on a preference, maybe the other way is better. I can update and make a new pull request.
##### Git Commit Message

Added green background for markup.inserted.diff and meta.diff.header.to-file. The green was taken from the Tomorrow color scheme.

Added red background for markup.deleted.diff and meta.diff.header.from-file. The red was taken from the Tomorrow color scheme.

Added italics text style for meta.diff.header.from-file and meta.diff.header.to-file.

Added white foreground color for meta.diff.header.from-file, meta.diff.header.to-file, markup.inserted.diff and markup.deleted.diff to improve legibility with the background.
