### PR TITLE
Vim - Tomorrow-Night - Adding color for `for` and `while` keywords in Python

### DIFF
--- a/vim/colors/Tomorrow-Night.vim
+++ b/vim/colors/Tomorrow-Night.vim
@@ -324,6 +324,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("pythonStatement", s:purple, "", "")
 	call <SID>X("pythonConditional", s:purple, "", "")
 	call <SID>X("pythonFunction", s:blue, "", "")
+	call <SID>X("pythonRepeat", s:aqua, "", "")
 
 	" JavaScript Highlighting
 	call <SID>X("javaScriptBraces", s:foreground, "", "")


### PR DESCRIPTION
The `for` and `while` keywords were lacking color, now they are colored in aqua since the `in` keyword is also in aqua.

I'm using:
 Mac OS X 10.7 Lion
 MacVIM - VIM - Vi IMproved 7.3 (2010 Aug 15, compiled Jan  2 2012 17:38:47) 
