### PR TITLE
Fix some colors in GNU Emacs

### DIFF
--- a/GNU Emacs/color-theme-tomorrow.el
+++ b/GNU Emacs/color-theme-tomorrow.el
@@ -20,7 +20,7 @@ theme will be used."
 
   (let ((background "#ffffff")
         (current-line "#e9efff")
-        (selection "#c5cce9")
+        (selection "#d6d6d6")
         (foreground "#4d4d4c")
         (comment "#8e908c")
         (cursor "#aeafad")
@@ -58,8 +58,8 @@ theme will be used."
                  orange "#f99157"
                  yellow "#ffcc66"
                  green "#99cc99"
-                 aqua "#009999"
-                 blue "#99cccc"
+                 aqua "#66cccc"
+                 blue "#6699cc"
                  purple "#cc99cc"))
 
           ((eq variant 'night-blue)
@@ -81,7 +81,7 @@ theme will be used."
            (setq background "#000000"
                  current-line "#2a2a2a"
                  selection "#424242"
-                 foreground "#dedede"
+                 foreground "#eaeaea"
                  comment "#969896"
                  cursor "#9f9f9f"
                  red "#d54e53"

--- a/GNU Emacs/tomorrow-night-bright-theme.el
+++ b/GNU Emacs/tomorrow-night-bright-theme.el
@@ -16,7 +16,7 @@
 (let ((background "#000000")
       (current-line "#2a2a2a")
       (selection "#424242")
-      (foreground "#dedede")
+      (foreground "#eaeaea")
       (comment "#969896")
       (cursor "#9f9f9f")
       (red "#d54e53")

--- a/GNU Emacs/tomorrow-night-eighties-theme.el
+++ b/GNU Emacs/tomorrow-night-eighties-theme.el
@@ -23,8 +23,8 @@
       (orange "#f99157")
       (yellow "#ffcc66")
       (green "#99cc99")
-      (aqua "#009999")
-      (blue "#99cccc")
+      (aqua "#66cccc")
+      (blue "#6699cc")
       (purple "#cc99cc"))
 
   (custom-theme-set-faces

--- a/GNU Emacs/tomorrow-theme.el
+++ b/GNU Emacs/tomorrow-theme.el
@@ -15,7 +15,7 @@
 
 (let ((background "#ffffff")
       (current-line "#e9efff")
-      (selection "#c5cce9")
+      (selection "#d6d6d6")
       (foreground "#4d4d4c")
       (comment "#8e908c")
       (cursor "#aeafad")


### PR DESCRIPTION
Some colors in the GNU Emacs themes were different than the ones in palette. This commit makes everything good again :)
