### PR TITLE
Add support for rainbow-delimiters in GNU Emacs

### DIFF
--- a/GNU Emacs/color-theme-tomorrow.el
+++ b/GNU Emacs/color-theme-tomorrow.el
@@ -133,7 +133,18 @@ theme will be used."
 
        ;; show-paren-mode
        (show-paren-match-face ((t (:background ,blue :foreground ,current-line))))
-       (show-paren-mismatch-face ((t (:background ,orange :foreground ,current-line))))))))
+       (show-paren-mismatch-face ((t (:background ,orange :foreground ,current-line))))
+
+       ;; rainbow-delimiters
+       (rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
+       (rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))
+       (rainbow-delimiters-depth-3-face ((t (:foreground ,aqua))))
+       (rainbow-delimiters-depth-4-face ((t (:foreground ,green))))
+       (rainbow-delimiters-depth-5-face ((t (:foreground ,yellow))))
+       (rainbow-delimiters-depth-6-face ((t (:foreground ,orange))))
+       (rainbow-delimiters-depth-7-face ((t (:foreground ,red))))
+       (rainbow-delimiters-depth-8-face ((t (:foreground ,comment))))
+       (rainbow-delimiters-depth-9-face ((t (:foreground ,foreground))))))))
 
 (defun color-theme-tomorrow ()
   "Base light Tomorrow theme."

--- a/GNU Emacs/tomorrow-night-blue-theme.el
+++ b/GNU Emacs/tomorrow-night-blue-theme.el
@@ -63,7 +63,18 @@
 
    ;; show-paren-mode
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
-   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line)))))
+   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
+
+   ;; rainbow-delimiters
+   `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
+   `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))
+   `(rainbow-delimiters-depth-3-face ((t (:foreground ,aqua))))
+   `(rainbow-delimiters-depth-4-face ((t (:foreground ,green))))
+   `(rainbow-delimiters-depth-5-face ((t (:foreground ,yellow))))
+   `(rainbow-delimiters-depth-6-face ((t (:foreground ,orange))))
+   `(rainbow-delimiters-depth-7-face ((t (:foreground ,red))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground ,comment))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground ,foreground)))))
 
   (custom-theme-set-variables
    'tomorrow-night-blue

--- a/GNU Emacs/tomorrow-night-bright-theme.el
+++ b/GNU Emacs/tomorrow-night-bright-theme.el
@@ -63,7 +63,18 @@
 
    ;; show-paren-mode
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
-   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line)))))
+   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
+
+   ;; rainbow-delimiters
+   `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
+   `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))
+   `(rainbow-delimiters-depth-3-face ((t (:foreground ,aqua))))
+   `(rainbow-delimiters-depth-4-face ((t (:foreground ,green))))
+   `(rainbow-delimiters-depth-5-face ((t (:foreground ,yellow))))
+   `(rainbow-delimiters-depth-6-face ((t (:foreground ,orange))))
+   `(rainbow-delimiters-depth-7-face ((t (:foreground ,red))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground ,comment))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground ,foreground)))))
 
   (custom-theme-set-variables
    'tomorrow-night-bright

--- a/GNU Emacs/tomorrow-night-eighties-theme.el
+++ b/GNU Emacs/tomorrow-night-eighties-theme.el
@@ -63,7 +63,18 @@
 
    ;; show-paren-mode
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
-   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line)))))
+   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
+
+   ;; rainbow-delimiters
+   `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
+   `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))
+   `(rainbow-delimiters-depth-3-face ((t (:foreground ,aqua))))
+   `(rainbow-delimiters-depth-4-face ((t (:foreground ,green))))
+   `(rainbow-delimiters-depth-5-face ((t (:foreground ,yellow))))
+   `(rainbow-delimiters-depth-6-face ((t (:foreground ,orange))))
+   `(rainbow-delimiters-depth-7-face ((t (:foreground ,red))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground ,comment))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground ,foreground)))))
 
   (custom-theme-set-variables
    'tomorrow-night-eighties

--- a/GNU Emacs/tomorrow-night-theme.el
+++ b/GNU Emacs/tomorrow-night-theme.el
@@ -63,7 +63,18 @@
 
    ;; show-paren-mode
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
-   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line)))))
+   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
+
+   ;; rainbow-delimiters
+   `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
+   `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))
+   `(rainbow-delimiters-depth-3-face ((t (:foreground ,aqua))))
+   `(rainbow-delimiters-depth-4-face ((t (:foreground ,green))))
+   `(rainbow-delimiters-depth-5-face ((t (:foreground ,yellow))))
+   `(rainbow-delimiters-depth-6-face ((t (:foreground ,orange))))
+   `(rainbow-delimiters-depth-7-face ((t (:foreground ,red))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground ,comment))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground ,foreground)))))
 
   (custom-theme-set-variables
    'tomorrow-night

--- a/GNU Emacs/tomorrow-theme.el
+++ b/GNU Emacs/tomorrow-theme.el
@@ -63,7 +63,18 @@
 
    ;; show-paren-mode
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
-   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line)))))
+   `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
+
+   ;; rainbow-delimiters
+   `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
+   `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))
+   `(rainbow-delimiters-depth-3-face ((t (:foreground ,aqua))))
+   `(rainbow-delimiters-depth-4-face ((t (:foreground ,green))))
+   `(rainbow-delimiters-depth-5-face ((t (:foreground ,yellow))))
+   `(rainbow-delimiters-depth-6-face ((t (:foreground ,orange))))
+   `(rainbow-delimiters-depth-7-face ((t (:foreground ,red))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground ,comment))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground ,foreground)))))
 
   (custom-theme-set-variables
    'tomorrow


### PR DESCRIPTION
Support [rainbow-delimiters](https://github.com/jlr/rainbow-delimiters) in GNU Emacs themes.
