### PR TITLE
Improve GNU Emacs support for Tomorrow Theme

### DIFF
--- a/GNU Emacs/color-theme-tomorrow.el
+++ b/GNU Emacs/color-theme-tomorrow.el
@@ -147,6 +147,18 @@ theme will be used."
        (show-paren-match-face ((t (:background ,blue :foreground ,current-line))))
        (show-paren-mismatch-face ((t (:background ,orange :foreground ,current-line))))
 
+       ;; whitespace-mode
+       (whitespace-empty ((t (:background ,yellow :foreground ,red))))
+       (whitespace-hspace ((t (:background ,selection :foreground ,comment))))
+       (whitespace-indentation ((t (:background ,yellow :foreground ,red))))
+       (whitespace-line ((t (:background ,current-line :foreground ,purple))))
+       (whitespace-newline ((t (:foreground ,comment))))
+       (whitespace-space ((t (:background ,current-line :foreground ,comment))))
+       (whitespace-space-after-tab ((t (:background ,yellow :foreground ,red))))
+       (whitespace-space-before-tab ((t (:background ,orange :foreground ,red))))
+       (whitespace-tab ((t (:background ,selection :foreground ,comment))))
+       (whitespace-trailing ((t (:background ,red :foreground ,yellow))))
+
        ;; rainbow-delimiters
        (rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
        (rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))

--- a/GNU Emacs/tomorrow-night-blue-theme.el
+++ b/GNU Emacs/tomorrow-night-blue-theme.el
@@ -77,6 +77,18 @@
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
    `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
 
+   ;; whitespace-mode
+   `(whitespace-empty ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-hspace ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-indentation ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-line ((t (:background ,current-line :foreground ,purple))))
+   `(whitespace-newline ((t (:foreground ,comment))))
+   `(whitespace-space ((t (:background ,current-line :foreground ,comment))))
+   `(whitespace-space-after-tab ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-space-before-tab ((t (:background ,orange :foreground ,red))))
+   `(whitespace-tab ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-trailing ((t (:background ,red :foreground ,yellow))))
+
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
    `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))

--- a/GNU Emacs/tomorrow-night-bright-theme.el
+++ b/GNU Emacs/tomorrow-night-bright-theme.el
@@ -77,6 +77,18 @@
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
    `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
 
+   ;; whitespace-mode
+   `(whitespace-empty ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-hspace ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-indentation ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-line ((t (:background ,current-line :foreground ,purple))))
+   `(whitespace-newline ((t (:foreground ,comment))))
+   `(whitespace-space ((t (:background ,current-line :foreground ,comment))))
+   `(whitespace-space-after-tab ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-space-before-tab ((t (:background ,orange :foreground ,red))))
+   `(whitespace-tab ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-trailing ((t (:background ,red :foreground ,yellow))))
+
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
    `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))

--- a/GNU Emacs/tomorrow-night-eighties-theme.el
+++ b/GNU Emacs/tomorrow-night-eighties-theme.el
@@ -77,6 +77,18 @@
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
    `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
 
+   ;; whitespace-mode
+   `(whitespace-empty ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-hspace ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-indentation ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-line ((t (:background ,current-line :foreground ,purple))))
+   `(whitespace-newline ((t (:foreground ,comment))))
+   `(whitespace-space ((t (:background ,current-line :foreground ,comment))))
+   `(whitespace-space-after-tab ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-space-before-tab ((t (:background ,orange :foreground ,red))))
+   `(whitespace-tab ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-trailing ((t (:background ,red :foreground ,yellow))))
+
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
    `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))

--- a/GNU Emacs/tomorrow-night-theme.el
+++ b/GNU Emacs/tomorrow-night-theme.el
@@ -77,6 +77,18 @@
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
    `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
 
+   ;; whitespace-mode
+   `(whitespace-empty ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-hspace ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-indentation ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-line ((t (:background ,current-line :foreground ,purple))))
+   `(whitespace-newline ((t (:foreground ,comment))))
+   `(whitespace-space ((t (:background ,current-line :foreground ,comment))))
+   `(whitespace-space-after-tab ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-space-before-tab ((t (:background ,orange :foreground ,red))))
+   `(whitespace-tab ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-trailing ((t (:background ,red :foreground ,yellow))))
+
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
    `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))

--- a/GNU Emacs/tomorrow-theme.el
+++ b/GNU Emacs/tomorrow-theme.el
@@ -77,6 +77,18 @@
    `(show-paren-match ((t (:background ,blue :foreground ,current-line))))
    `(show-paren-mismatch ((t (:background ,orange :foreground ,current-line))))
 
+   ;; whitespace-mode
+   `(whitespace-empty ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-hspace ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-indentation ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-line ((t (:background ,current-line :foreground ,purple))))
+   `(whitespace-newline ((t (:foreground ,comment))))
+   `(whitespace-space ((t (:background ,current-line :foreground ,comment))))
+   `(whitespace-space-after-tab ((t (:background ,yellow :foreground ,red))))
+   `(whitespace-space-before-tab ((t (:background ,orange :foreground ,red))))
+   `(whitespace-tab ((t (:background ,selection :foreground ,comment))))
+   `(whitespace-trailing ((t (:background ,red :foreground ,yellow))))
+
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,purple))))
    `(rainbow-delimiters-depth-2-face ((t (:foreground ,blue))))


### PR DESCRIPTION
Hi Chris,

Tomorrow Theme looks really good, and I'm working my way to improving its Emacs 23 and 24 support by adding faces for commonly used modes, as well as updating missing built-in faces. I'm checking in new modes as I go along, trying to respect the original intent of the mode's syntax colouring, while making it look good for every theme variation.

Is this something you are interested in merging back into master?

Cheers,

Arnaud.
