### PR TITLE
The inline widget is messed up in Brackets

### DIFF
--- a/Brackets/brackets_theme_tomorrow.less
+++ b/Brackets/brackets_theme_tomorrow.less
@@ -102,9 +102,9 @@
 @accent-plus: @green;
 
 /* inline editor colors */
-@inline-background-color-1: lighten(@background, @bc-color-step-size);
-@inline-background-color-2: lighten(@background, @bc-color-step-size*2);
-@inline-background-color-3: lighten(@background, @bc-color-step-size*3);
+@inline-background-color-1: darken(@background, @bc-color-step-size);
+@inline-background-color-2: darken(@background, @bc-color-step-size*3);
+@inline-background-color-3: rgba(0,0,0,0);
 
 @inline-color-1: darken(@foreground, @bc-color-step-size*2);
 @inline-color-2: darken(@foreground, @bc-color-step-size);

--- a/Brackets/brackets_theme_tomorrow_night.less
+++ b/Brackets/brackets_theme_tomorrow_night.less
@@ -102,12 +102,11 @@
 /* inline editor colors */
 @inline-background-color-1: lighten(@background, @bc-color-step-size);
 @inline-background-color-2: lighten(@background, @bc-color-step-size*2);
-@inline-background-color-3: lighten(@background, @bc-color-step-size*3);
 @inline-background-color-3: rgba(0,0,0,0);
 
 @inline-color-1: darken(@foreground, @bc-color-step-size*2);
 @inline-color-2: darken(@foreground, @bc-color-step-size);
-@inline-color-3: @foreground;
+@inline-color-3: @background;
 
 /* Code font formatting
  *

--- a/Brackets/brackets_theme_tomorrow_night_blue.less
+++ b/Brackets/brackets_theme_tomorrow_night_blue.less
@@ -102,11 +102,11 @@
 /* inline editor colors */
 @inline-background-color-1: lighten(@background, @bc-color-step-size);
 @inline-background-color-2: lighten(@background, @bc-color-step-size*2);
-@inline-background-color-3: lighten(@background, @bc-color-step-size*3);
+@inline-background-color-3: rgba(0,0,0,0);
 
 @inline-color-1: darken(@foreground, @bc-color-step-size*2);
 @inline-color-2: darken(@foreground, @bc-color-step-size);
-@inline-color-3: @foreground;
+@inline-color-3: @background;
 
 /* Code font formatting
  *

--- a/Brackets/brackets_theme_tomorrow_night_bright.less
+++ b/Brackets/brackets_theme_tomorrow_night_bright.less
@@ -102,11 +102,11 @@
 /* inline editor colors */
 @inline-background-color-1: lighten(@background, @bc-color-step-size);
 @inline-background-color-2: lighten(@background, @bc-color-step-size*2);
-@inline-background-color-3: lighten(@background, @bc-color-step-size*3);
+@inline-background-color-3: rgba(0,0,0,0);
 
 @inline-color-1: darken(@foreground, @bc-color-step-size*2);
 @inline-color-2: darken(@foreground, @bc-color-step-size);
-@inline-color-3: @foreground;
+@inline-color-3: @background;
 
 /* Code font formatting
  *

--- a/Brackets/brackets_theme_tomorrow_night_eighties.less
+++ b/Brackets/brackets_theme_tomorrow_night_eighties.less
@@ -46,8 +46,6 @@
 @blue: #6699cc;
 @purple: #cc99cc;
 
-
-
 /* 
  * Background colors are ordered from least "intense" to most "intense"
  * So, if the background is light, then @background-color-3 should be
@@ -104,11 +102,11 @@
 /* inline editor colors */
 @inline-background-color-1: lighten(@background, @bc-color-step-size);
 @inline-background-color-2: lighten(@background, @bc-color-step-size*2);
-@inline-background-color-3: lighten(@background, @bc-color-step-size*3);
+@inline-background-color-3: rgba(0,0,0,0);
 
 @inline-color-1: darken(@foreground, @bc-color-step-size*2);
 @inline-color-2: darken(@foreground, @bc-color-step-size);
-@inline-color-3: @foreground;
+@inline-color-3: @background;
 
 /* Code font formatting
  *


### PR DESCRIPTION
In the Brackets IDE, the theme is weird in a small area, but it needed to be corrected. I fixed it for all the themes. To see the change/flaws, apply the theme, click on a html element, and type CMD+E.

Before:
![Before Fix](https://f.cloud.github.com/assets/833787/12574/0a32bd0c-45a3-11e2-9a3f-1292146870ab.png)

After:
![After Fix](https://f.cloud.github.com/assets/833787/12569/a16b7e08-45a2-11e2-80c0-1b515588cd47.png)
