### PR TITLE
Added support for new Emacs major modes

### DIFF
--- a/GNU Emacs/color-theme-tomorrow.el
+++ b/GNU Emacs/color-theme-tomorrow.el
@@ -186,6 +186,11 @@ theme will be used."
        (font-latex-verbatim-face ((t (:foreground ,orange))))
        (font-latex-warning-face ((t (:foreground ,red))))
 
+       ;; ido-mode
+       (ido-first-match ((t (:foreground ,orange :weight bold))))
+       (ido-only-match ((t (:foreground ,red :weight bold))))
+       (ido-subdir ((t (:foreground ,comment))))
+
        ;; diff-mode
        (diff-added ((t (:foreground ,green))))
        (diff-changed ((t (:foreground ,yellow))))

--- a/GNU Emacs/tomorrow-night-blue-theme.el
+++ b/GNU Emacs/tomorrow-night-blue-theme.el
@@ -116,7 +116,12 @@
    `(font-latex-verbatim-face ((t (:foreground ,orange))))
    `(font-latex-warning-face ((t (:foreground ,red))))
 
-   ;; diff
+   ;; ido-mode
+   `(ido-first-match ((t (:foreground ,orange :weight bold))))
+   `(ido-only-match ((t (:foreground ,red :weight bold))))
+   `(ido-subdir ((t (:foreground ,comment))))
+
+   ;; diff-mode
    `(diff-added ((t (:foreground ,green))))
    `(diff-changed ((t (:foreground ,yellow))))
    `(diff-removed ((t (:foreground ,red))))
@@ -124,7 +129,7 @@
    `(diff-file-header ((t (:background ,selection))))
    `(diff-hunk-header ((t (:background ,current-line :foreground ,blue))))
 
-   ;; magit
+   ;; magit-mode
    `(magit-section-title ((t (:inherit diff-hunk-header))))
    `(magit-log-graph ((t (:foreground ,comment))))
    `(magit-log-sha1 ((t (:foreground ,purple))))

--- a/GNU Emacs/tomorrow-night-bright-theme.el
+++ b/GNU Emacs/tomorrow-night-bright-theme.el
@@ -116,6 +116,12 @@
    `(font-latex-verbatim-face ((t (:foreground ,orange))))
    `(font-latex-warning-face ((t (:foreground ,red))))
 
+   ;; ido-mode
+   `(ido-first-match ((t (:foreground ,orange :weight bold))))
+   `(ido-only-match ((t (:foreground ,red :weight bold))))
+   `(ido-subdir ((t (:foreground ,comment))))
+
+   ;; diff-mode
    `(diff-added ((t (:foreground ,green))))
    `(diff-changed ((t (:foreground ,yellow))))
    `(diff-removed ((t (:foreground ,red))))
@@ -123,7 +129,7 @@
    `(diff-file-header ((t (:background ,selection))))
    `(diff-hunk-header ((t (:background ,current-line :foreground ,blue))))
 
-   ;; magit
+   ;; magit-mode
    `(magit-section-title ((t (:inherit diff-hunk-header))))
    `(magit-log-graph ((t (:foreground ,comment))))
    `(magit-log-sha1 ((t (:foreground ,purple))))

--- a/GNU Emacs/tomorrow-night-eighties-theme.el
+++ b/GNU Emacs/tomorrow-night-eighties-theme.el
@@ -116,7 +116,12 @@
    `(font-latex-verbatim-face ((t (:foreground ,orange))))
    `(font-latex-warning-face ((t (:foreground ,red))))
 
-   ;; diff
+   ;; ido-mode
+   `(ido-first-match ((t (:foreground ,orange :weight bold))))
+   `(ido-only-match ((t (:foreground ,red :weight bold))))
+   `(ido-subdir ((t (:foreground ,comment))))
+
+   ;; diff-mode
    `(diff-added ((t (:foreground ,green))))
    `(diff-changed ((t (:foreground ,yellow))))
    `(diff-removed ((t (:foreground ,red))))
@@ -124,7 +129,7 @@
    `(diff-file-header ((t (:background ,selection))))
    `(diff-hunk-header ((t (:background ,current-line :foreground ,blue))))
 
-   ;; magit
+   ;; magit-mode
    `(magit-section-title ((t (:inherit diff-hunk-header))))
    `(magit-log-graph ((t (:foreground ,comment))))
    `(magit-log-sha1 ((t (:foreground ,purple))))

--- a/GNU Emacs/tomorrow-night-theme.el
+++ b/GNU Emacs/tomorrow-night-theme.el
@@ -116,7 +116,12 @@
    `(font-latex-verbatim-face ((t (:foreground ,orange))))
    `(font-latex-warning-face ((t (:foreground ,red))))
 
-   ;; diff
+   ;; ido-mode
+   `(ido-first-match ((t (:foreground ,orange :weight bold))))
+   `(ido-only-match ((t (:foreground ,red :weight bold))))
+   `(ido-subdir ((t (:foreground ,comment))))
+
+   ;; diff-mode
    `(diff-added ((t (:foreground ,green))))
    `(diff-changed ((t (:foreground ,yellow))))
    `(diff-removed ((t (:foreground ,red))))
@@ -124,7 +129,7 @@
    `(diff-file-header ((t (:background ,selection))))
    `(diff-hunk-header ((t (:background ,current-line :foreground ,blue))))
 
-   ;; magit
+   ;; magit-mode
    `(magit-section-title ((t (:inherit diff-hunk-header))))
    `(magit-log-graph ((t (:foreground ,comment))))
    `(magit-log-sha1 ((t (:foreground ,purple))))

--- a/GNU Emacs/tomorrow-theme.el
+++ b/GNU Emacs/tomorrow-theme.el
@@ -100,7 +100,12 @@
    `(rainbow-delimiters-depth-8-face ((t (:foreground ,comment))))
    `(rainbow-delimiters-depth-9-face ((t (:foreground ,foreground))))
 
-   ;; diff
+   ;; ido-mode
+   `(ido-first-match ((t (:foreground ,orange :weight bold))))
+   `(ido-only-match ((t (:foreground ,red :weight bold))))
+   `(ido-subdir ((t (:foreground ,comment))))
+
+   ;; diff-mode
    `(diff-added ((t (:foreground ,green))))
    `(diff-changed ((t (:foreground ,yellow))))
    `(diff-removed ((t (:foreground ,red))))
@@ -108,7 +113,7 @@
    `(diff-file-header ((t (:background ,selection))))
    `(diff-hunk-header ((t (:background ,current-line :foreground ,blue))))
 
-   ;; magit
+   ;; magit-mode
    `(magit-section-title ((t (:inherit diff-hunk-header))))
    `(magit-log-graph ((t (:foreground ,comment))))
    `(magit-log-sha1 ((t (:foreground ,purple))))


### PR DESCRIPTION
Added support for `diff-mode` and `magit-mode` and improved support for `ido-mode`. These changes were applied in all Emacs theme variations.

Please take a look at the following images to see how the changes look like in `tomorrow-night`.

![diff-mode](https://f.cloud.github.com/assets/29534/110523/3f507786-6ac4-11e2-94ad-e79a5f347b4e.png)

![magit-mode](https://f.cloud.github.com/assets/29534/110526/50b6cf2a-6ac4-11e2-9b3d-a26a257f8ed7.png)

![ido-mode](https://f.cloud.github.com/assets/29534/110525/4d191c60-6ac4-11e2-823f-35397f37693d.png)
