### PR TITLE
bugfix: don't make current line invisible in emacs

### DIFF
--- a/GNU Emacs/color-theme-tomorrow.el
+++ b/GNU Emacs/color-theme-tomorrow.el
@@ -191,7 +191,7 @@ names to which it refers are bound."
      (hl-line ((,class (:background ,current-line))))
      (border ((,class (:background ,current-line))))
      (border-glyph ((,class (nil))))
-     (highlight ((,class (:foreground ,current-line :background ,green))))
+     (highlight ((,class (:background ,green))))
      (link ((,class (:foreground ,blue))))
      (link-visited ((,class (:foreground ,purple))))
      (gui-element ((,class (:background ,current-line :foreground ,foreground))))


### PR DESCRIPTION
in emacs24, the foreground and background end up the same color so you can't see anything for the current line
