### PR TITLE
Support for gconftool-2 for Gnome Terminal

### DIFF
--- a/Gnome-Terminal/setup-theme.sh
+++ b/Gnome-Terminal/setup-theme.sh
@@ -2,7 +2,11 @@
 
 [[ -z "$PROFILE_NAME" ]] && PROFILE_NAME=Tomorrow
 [[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG=Tomorrow
-[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gconftool
+if hash gconftool 2>/dev/null; then
+	[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gconftool
+else
+	[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gconftool-2
+fi
 [[ -z "$BASE_KEY" ]] && BASE_KEY=/apps/gnome-terminal/profiles
 
 PROFILE_KEY="$BASE_KEY/$PROFILE_SLUG"


### PR DESCRIPTION
some distros (fedora 18) are now only shipping with the new version of gconftool, this commit recognizes both versions.
