### PR TITLE
Brackets' theme update to work with Sprint 24

### DIFF
--- a/Brackets/brackets_theme_tomorrow.less
+++ b/Brackets/brackets_theme_tomorrow.less
@@ -46,8 +46,6 @@
 @blue: #4271ae;
 @purple: #8959a8;
 
-
-
 /* 
  * Background colors are ordered from least "intense" to most "intense"
  * So, if the background is light, then @background-color-3 should be
@@ -112,6 +110,8 @@
 
 /* sidebar/toolbar colors */
 @project-panel-base-color: #3C3F41;
+@project-panel-text-1: #ffffff;
+@project-panel-text-2: #8e9a9d;
 @main-toolbar-background-color: #5D5F60;
 
 /* Selection colors */

--- a/Brackets/brackets_theme_tomorrow.less
+++ b/Brackets/brackets_theme_tomorrow.less
@@ -114,6 +114,9 @@
 @selection-color-focused: #d2dcf8;
 @selection-color-unfocused: #d9d9d9;
 
+/* background color of the line that has the cursor */
+@activeline-bgcolor: @current-line;
+
 /* Code font formatting
  *
  * NOTE (JRB): In order to get the web font to load early enough, we have a div called "dummy-text" that

--- a/Brackets/brackets_theme_tomorrow.less
+++ b/Brackets/brackets_theme_tomorrow.less
@@ -110,6 +110,10 @@
 @inline-color-2: darken(@foreground, @bc-color-step-size);
 @inline-color-3: @foreground;
 
+/* sidebar/toolbar colors */
+@project-panel-base-color: #3C3F41;
+@main-toolbar-background-color: #5D5F60;
+
 /* Selection colors */
 @selection-color-focused: #d2dcf8;
 @selection-color-unfocused: #d9d9d9;

--- a/Brackets/brackets_theme_tomorrow_night.less
+++ b/Brackets/brackets_theme_tomorrow_night.less
@@ -110,6 +110,8 @@
 
 /* sidebar/toolbar colors */
 @project-panel-base-color: #3C3F41;
+@project-panel-text-1: #ffffff;
+@project-panel-text-2: #8e9a9d;
 @main-toolbar-background-color: #5D5F60;
 
 /* Selection colors */

--- a/Brackets/brackets_theme_tomorrow_night.less
+++ b/Brackets/brackets_theme_tomorrow_night.less
@@ -112,6 +112,9 @@
 @selection-color-focused: #585858;
 @selection-color-unfocused: #424242;
 
+/* background color of the line that has the cursor */
+@activeline-bgcolor: @current-line;
+
 /* Code font formatting
  *
  * NOTE (JRB): In order to get the web font to load early enough, we have a div called "dummy-text" that

--- a/Brackets/brackets_theme_tomorrow_night.less
+++ b/Brackets/brackets_theme_tomorrow_night.less
@@ -108,6 +108,10 @@
 @inline-color-2: darken(@foreground, @bc-color-step-size);
 @inline-color-3: @background;
 
+/* sidebar/toolbar colors */
+@project-panel-base-color: #3C3F41;
+@main-toolbar-background-color: #5D5F60;
+
 /* Selection colors */
 @selection-color-focused: #585858;
 @selection-color-unfocused: #424242;

--- a/Brackets/brackets_theme_tomorrow_night_blue.less
+++ b/Brackets/brackets_theme_tomorrow_night_blue.less
@@ -108,6 +108,10 @@
 @inline-color-2: darken(@foreground, @bc-color-step-size);
 @inline-color-3: @background;
 
+/* sidebar/toolbar colors */
+@project-panel-base-color: #3C3F41;
+@main-toolbar-background-color: #5D5F60;
+
 /* Selection colors */
 @selection-color-focused: #405db1;
 @selection-color-unfocused: #4a5c87;

--- a/Brackets/brackets_theme_tomorrow_night_blue.less
+++ b/Brackets/brackets_theme_tomorrow_night_blue.less
@@ -112,6 +112,9 @@
 @selection-color-focused: #405db1;
 @selection-color-unfocused: #4a5c87;
 
+/* background color of the line that has the cursor */
+@activeline-bgcolor: @current-line;
+
 /* Code font formatting
  *
  * NOTE (JRB): In order to get the web font to load early enough, we have a div called "dummy-text" that

--- a/Brackets/brackets_theme_tomorrow_night_blue.less
+++ b/Brackets/brackets_theme_tomorrow_night_blue.less
@@ -110,6 +110,8 @@
 
 /* sidebar/toolbar colors */
 @project-panel-base-color: #3C3F41;
+@project-panel-text-1: #ffffff;
+@project-panel-text-2: #8e9a9d;
 @main-toolbar-background-color: #5D5F60;
 
 /* Selection colors */

--- a/Brackets/brackets_theme_tomorrow_night_bright.less
+++ b/Brackets/brackets_theme_tomorrow_night_bright.less
@@ -110,6 +110,8 @@
 
 /* sidebar/toolbar colors */
 @project-panel-base-color: #3C3F41;
+@project-panel-text-1: #ffffff;
+@project-panel-text-2: #8e9a9d;
 @main-toolbar-background-color: #5D5F60;
 
 /* Selection colors */

--- a/Brackets/brackets_theme_tomorrow_night_bright.less
+++ b/Brackets/brackets_theme_tomorrow_night_bright.less
@@ -112,6 +112,9 @@
 @selection-color-focused: #585858;
 @selection-color-unfocused: #424242;
 
+/* background color of the line that has the cursor */
+@activeline-bgcolor: @current-line;
+
 /* Code font formatting
  *
  * NOTE (JRB): In order to get the web font to load early enough, we have a div called "dummy-text" that

--- a/Brackets/brackets_theme_tomorrow_night_bright.less
+++ b/Brackets/brackets_theme_tomorrow_night_bright.less
@@ -108,6 +108,10 @@
 @inline-color-2: darken(@foreground, @bc-color-step-size);
 @inline-color-3: @background;
 
+/* sidebar/toolbar colors */
+@project-panel-base-color: #3C3F41;
+@main-toolbar-background-color: #5D5F60;
+
 /* Selection colors */
 @selection-color-focused: #585858;
 @selection-color-unfocused: #424242;

--- a/Brackets/brackets_theme_tomorrow_night_eighties.less
+++ b/Brackets/brackets_theme_tomorrow_night_eighties.less
@@ -110,6 +110,8 @@
 
 /* sidebar/toolbar colors */
 @project-panel-base-color: #3C3F41;
+@project-panel-text-1: #ffffff;
+@project-panel-text-2: #8e9a9d;
 @main-toolbar-background-color: #5D5F60;
 
 /* Selection colors */

--- a/Brackets/brackets_theme_tomorrow_night_eighties.less
+++ b/Brackets/brackets_theme_tomorrow_night_eighties.less
@@ -112,6 +112,9 @@
 @selection-color-focused: #585858;
 @selection-color-unfocused: #424242;
 
+/* background color of the line that has the cursor */
+@activeline-bgcolor: @current-line;
+
 /* Code font formatting
  *
  * NOTE (JRB): In order to get the web font to load early enough, we have a div called "dummy-text" that

--- a/Brackets/brackets_theme_tomorrow_night_eighties.less
+++ b/Brackets/brackets_theme_tomorrow_night_eighties.less
@@ -108,6 +108,10 @@
 @inline-color-2: darken(@foreground, @bc-color-step-size);
 @inline-color-3: @background;
 
+/* sidebar/toolbar colors */
+@project-panel-base-color: #3C3F41;
+@main-toolbar-background-color: #5D5F60;
+
 /* Selection colors */
 @selection-color-focused: #585858;
 @selection-color-unfocused: #424242;


### PR DESCRIPTION
_The pull request updated with fix for Spring 23_

There is a new option presented into the Brackets Sprint 22 - highlight active line. The theme files need these two lines added to them to let Brackets work properly:

`/* background color of the line that has the cursor */
@activeline-bgcolor: @current-line;`

Brackets Sprint 23 fix: 

`/* sidebar/toolbar colors */
@project-panel-base-color: #3C3F41;
@main-toolbar-background-color: #5D5F60;`

Brackets Sprint 24 fix:
`/* sidebar/toolbar colors */
@project-panel-text-1: #ffffff;
@project-panel-text-2: #8e9a9d;`

p.s. there is a small hickup with colors in Web Platform Docs module widget that still needs to be addressed (dark theme generally). I am trying to figure out where to burry my hands to change it to show more readable values
