### PR TITLE
Proper syntax highlighting to Python docstrings in Sublime Text

### DIFF
--- a/textmate/Tomorrow-Night-Blue.tmTheme
+++ b/textmate/Tomorrow-Night-Blue.tmTheme
@@ -29,7 +29,7 @@
 			<key>name</key>
 			<string>Comment</string>
 			<key>scope</key>
-			<string>comment</string>
+			<string>comment, string.quoted.double.block.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -189,7 +189,7 @@
 				<key>foreground</key>
 				<string>#FFFFFF</string>
 			</dict>
-		</dict>				
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff insertion</string>
@@ -224,7 +224,7 @@
 				<key>background</key>
 				<string>#4271ae</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff range</string>
@@ -237,7 +237,7 @@
 				<key>foreground</key>
 				<string>#3e999f</string>
 			</dict>
-		</dict>	
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>3F4BB232-3C3A-4396-99C0-06A9573715E9</string>

--- a/textmate/Tomorrow-Night-Bright.tmTheme
+++ b/textmate/Tomorrow-Night-Bright.tmTheme
@@ -29,7 +29,7 @@
 			<key>name</key>
 			<string>Comment</string>
 			<key>scope</key>
-			<string>comment</string>
+			<string>comment, string.quoted.double.block.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -189,7 +189,7 @@
 				<key>foreground</key>
 				<string>#FFFFFF</string>
 			</dict>
-		</dict>				
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff insertion</string>
@@ -224,7 +224,7 @@
 				<key>background</key>
 				<string>#4271ae</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff range</string>

--- a/textmate/Tomorrow-Night-Eighties.tmTheme
+++ b/textmate/Tomorrow-Night-Eighties.tmTheme
@@ -29,7 +29,7 @@
 			<key>name</key>
 			<string>Comment</string>
 			<key>scope</key>
-			<string>comment</string>
+			<string>comment, string.quoted.double.block.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -189,7 +189,7 @@
 				<key>foreground</key>
 				<string>#FFFFFF</string>
 			</dict>
-		</dict>				
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff insertion</string>
@@ -224,7 +224,7 @@
 				<key>background</key>
 				<string>#4271ae</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff range</string>

--- a/textmate/Tomorrow-Night.tmTheme
+++ b/textmate/Tomorrow-Night.tmTheme
@@ -29,7 +29,7 @@
 			<key>name</key>
 			<string>Comment</string>
 			<key>scope</key>
-			<string>comment</string>
+			<string>comment, string.quoted.double.block.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -189,7 +189,7 @@
 				<key>foreground</key>
 				<string>#FFFFFF</string>
 			</dict>
-		</dict>				
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff insertion</string>
@@ -224,7 +224,7 @@
 				<key>background</key>
 				<string>#4271ae</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff range</string>
@@ -237,7 +237,7 @@
 				<key>foreground</key>
 				<string>#3e999f</string>
 			</dict>
-		</dict>		
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>F96223EB-1A60-4617-92F3-D24D4F13DB09</string>

--- a/textmate/Tomorrow.tmTheme
+++ b/textmate/Tomorrow.tmTheme
@@ -29,7 +29,7 @@
 			<key>name</key>
 			<string>Comment</string>
 			<key>scope</key>
-			<string>comment</string>
+			<string>comment, string.quoted.double.block.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -189,7 +189,7 @@
 				<key>foreground</key>
 				<string>#FFFFFF</string>
 			</dict>
-		</dict>				
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff insertion</string>
@@ -224,7 +224,7 @@
 				<key>background</key>
 				<string>#4271ae</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff range</string>


### PR DESCRIPTION
In Sublime Text 2, comments in the docstring format gets highlighted as
string. And it should be formatted as comment.
