### PR TITLE
VIM: Fix unstyled SignColumn

### DIFF
--- a/vim/colors/Tomorrow-Night-Eighties.vim
+++ b/vim/colors/Tomorrow-Night-Eighties.vim
@@ -234,6 +234,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 
 	" Vim Highlighting
 	call <SID>X("Normal", s:foreground, s:background, "")
+	call <SID>X("SignColumn", s:foreground, s:background, "")
 	call <SID>X("LineNr", s:selection, "", "")
 	call <SID>X("NonText", s:selection, "", "")
 	call <SID>X("SpecialKey", s:selection, "", "")


### PR DESCRIPTION
SignColumn was unstyled and 
