### PR TITLE
vim: Prevent `set background=dark` from being reset

### DIFF
--- a/vim/colors/Tomorrow-Night-Blue.vim
+++ b/vim/colors/Tomorrow-Night-Blue.vim
@@ -18,7 +18,6 @@ let s:blue = "bbdaff"
 let s:purple = "ebbbff"
 let s:window = "4d5057"
 
-set background=dark
 hi clear
 syntax reset
 
@@ -375,3 +374,5 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	delf <SID>grey_level
 	delf <SID>grey_number
 endif
+
+set background=dark

--- a/vim/colors/Tomorrow-Night-Bright.vim
+++ b/vim/colors/Tomorrow-Night-Bright.vim
@@ -18,7 +18,6 @@ let s:blue = "7aa6da"
 let s:purple = "c397d8"
 let s:window = "4d5057"
 
-set background=dark
 hi clear
 syntax reset
 
@@ -375,3 +374,5 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	delf <SID>grey_level
 	delf <SID>grey_number
 endif
+
+set background=dark

--- a/vim/colors/Tomorrow-Night-Eighties.vim
+++ b/vim/colors/Tomorrow-Night-Eighties.vim
@@ -18,7 +18,6 @@ let s:blue = "99cccc"
 let s:purple = "cc99cc"
 let s:window = "4d5057"
 
-set background=dark
 hi clear
 syntax reset
 
@@ -375,3 +374,5 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	delf <SID>grey_level
 	delf <SID>grey_number
 endif
+
+set background=dark

--- a/vim/colors/Tomorrow-Night.vim
+++ b/vim/colors/Tomorrow-Night.vim
@@ -26,7 +26,6 @@ if !has("gui_running")
 	let s:selection = "585858"
 end
 
-set background=dark
 hi clear
 syntax reset
 
@@ -391,3 +390,5 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	delf <SID>grey_level
 	delf <SID>grey_number
 endif
+
+set background=dark


### PR DESCRIPTION
The call to `<SID>X("Normal", s:foreground, s:background, "")` resets
the background option and since VIm fails to detect the dark background
it gets set to `light`.

Moving the `set background=dark` call at the end fixes it.
