### PR TITLE
Make diredp-dir-heading inherit face from dired-header.

### DIFF
--- a/GNU Emacs/color-theme-tomorrow.el
+++ b/GNU Emacs/color-theme-tomorrow.el
@@ -512,7 +512,16 @@ names to which it refers are bound."
      (custom-variable-tag ((,class (:foreground ,blue))))
      (custom-group-tag ((,class (:foreground ,blue))))
      (custom-state ((,class (:foreground ,green))))
-     )))
+     
+     ;; term
+     (term-color-black ((,class (:foreground ,background :background ,background))))
+     (term-color-blue ((,class (:foreground ,blue :background ,blue))))
+     (term-color-cyan ((,class (:foreground ,aqua :background ,aqua))))
+     (term-color-green ((,class (:foreground ,green :background ,green))))
+     (term-color-magenta ((,class (:foreground ,purple :background ,purple))))
+     (term-color-red ((,class (:foreground ,red :background ,red))))
+     (term-color-white ((,class (:foreground ,foreground :background ,foreground))))
+     (term-color-yellow ((,class (:foreground ,yellow :background ,yellow)))))))
 
 (defmacro color-theme-tomorrow--frame-parameter-specs ()
   "Return a backquote which defines a list of frame parameter specs.

--- a/GNU Emacs/color-theme-tomorrow.el
+++ b/GNU Emacs/color-theme-tomorrow.el
@@ -278,7 +278,7 @@ names to which it refers are bound."
 
      ;; dired+
      (diredp-compressed-file-suffix ((,class (:foreground ,blue))))
-     (diredp-dir-heading ((,class (:foreground nil :background nil :inherit heading))))
+     (diredp-dir-heading ((,class (:foreground nil :background nil :inherit dired-header))))
      (diredp-dir-priv ((,class (:foreground ,aqua :background nil))))
      (diredp-exec-priv ((,class (:foreground ,blue :background nil))))
      (diredp-executable-tag ((,class (:foreground ,red :background nil))))


### PR DESCRIPTION
`diredp-dir-heading` tries to inherit face attributes from the face `heading`.  `heading` is not a defined face in a standard Emacs installation or this theme.

`dired-header` should always exist as `dired` is a part of GNU Emacs.

This problem presented itself when I was attempting to successfully call `org-html-htmlize-generate-css`.  An error is thrown by `face-attribute` which chokes on the undefined face and halts execution of the CSS generation function.  `htmlize.el` could do a better job of handling invalid faces.  I've searched for that repository to suggest a patch without any luck.  Regardless, inheriting from a non-standard undefined face is probably not a great idea.
