### PR TITLE
Updated to support newest Gnome Terminal

### DIFF
--- a/Gnome-Terminal/setup-theme.sh
+++ b/Gnome-Terminal/setup-theme.sh
@@ -35,24 +35,25 @@ dlist_append() {
 if which "$DCONF" > /dev/null 2>&1; then
 	[[ -z "$BASE_KEY" ]] && BASE_KEY=/org/gnome/terminal/legacy/profiles:
 
-	if [[ -n "`$DCONF read $BASE_KEY/list`" ]]; then
+	if [[ -n "`$DCONF list $BASE_KEY/`" ]]; then
 		if which "$UUIDGEN" > /dev/null 2>&1; then
 			PROFILE_SLUG=`uuidgen`
 		fi
 
-		DEFAULT_SLUG=`$DCONF read $BASE_KEY/default | tr -d \'`
+    if [[ -n "`$DCONF read $BASE_KEY/default`" ]]; then
+      DEFAULT_SLUG=`$DCONF read $BASE_KEY/default | tr -d \'`
+    else
+      DEFAULT_SLUG=`$DCONF list $BASE_KEY/ | grep '^:' | head -n1 | tr -d :/`
+    fi
+
 		DEFAULT_KEY="$BASE_KEY/:$DEFAULT_SLUG"
 		PROFILE_KEY="$BASE_KEY/:$PROFILE_SLUG"
-
-		echo "$DEFAULT_SLUG"
-		echo "$DEFAULT_KEY"
-		echo "$PROFILE_KEY"
 
 		# copy existing settings from default profile
 		$DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
 
 		# add new copy to list of profiles
-		dlist_append $BASE_KEY/list "$PROFILE_SLUG"
+    dlist_append $BASE_KEY/list "$PROFILE_SLUG"
 
 		# update profile values with theme options
 		dset visible-name "'$PROFILE_NAME'"


### PR DESCRIPTION
The latest versions of Gnome Terminal store their settings and profiles
using the newer dconf system rather than gconf.  As such, the script
will now detect both the presence of dconf and the appropriate dconf
keys for Gnome Terminal.  When the dconf keys are not found, then it
will gracefully fall back to the old method using gconf.

I have tested this on Gnome Shell version 3.8.  I have not tested on any previous versions, but I have tested the conditionals with non-existent binaries and config keys, and I am satisfied that it will fall back to the previous (unmodified) code appropriately.
