### PR TITLE
Add entity.name.filename scope to make Sublime Test project-wide search results easier to parse.

### DIFF
--- a/textmate/Tomorrow-Night-Blue.tmTheme
+++ b/textmate/Tomorrow-Night-Blue.tmTheme
@@ -90,7 +90,7 @@
 			<key>name</key>
 			<string>String, Symbols, Inherited Class, Markup Heading, GitGutter inserted</string>
 			<key>scope</key>
-			<string>string, constant.other.symbol, entity.other.inherited-class, markup.heading, markup.inserted.git_gutter</string>
+			<string>string, constant.other.symbol, entity.other.inherited-class, entity.name.filename, markup.heading, markup.inserted.git_gutter</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>

--- a/textmate/Tomorrow-Night-Bright.tmTheme
+++ b/textmate/Tomorrow-Night-Bright.tmTheme
@@ -90,7 +90,7 @@
 			<key>name</key>
 			<string>String, Symbols, Inherited Class, Markup Heading, GitGutter inserted</string>
 			<key>scope</key>
-			<string>string, constant.other.symbol, entity.other.inherited-class, markup.heading, markup.inserted.git_gutter</string>
+			<string>string, constant.other.symbol, entity.other.inherited-class, entity.name.filename, markup.heading, markup.inserted.git_gutter</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>

--- a/textmate/Tomorrow-Night-Eighties.tmTheme
+++ b/textmate/Tomorrow-Night-Eighties.tmTheme
@@ -90,7 +90,7 @@
 			<key>name</key>
 			<string>String, Symbols, Inherited Class, Markup Heading, GitGutter inserted</string>
 			<key>scope</key>
-			<string>string, constant.other.symbol, entity.other.inherited-class, markup.heading, markup.inserted.git_gutter</string>
+			<string>string, constant.other.symbol, entity.other.inherited-class, entity.name.filename, markup.heading, markup.inserted.git_gutter</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>
@@ -189,7 +189,7 @@
 				<key>foreground</key>
 				<string>#FFFFFF</string>
 			</dict>
-		</dict>				
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff insertion</string>
@@ -224,7 +224,7 @@
 				<key>background</key>
 				<string>#4271ae</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Diff range</string>

--- a/textmate/Tomorrow-Night.tmTheme
+++ b/textmate/Tomorrow-Night.tmTheme
@@ -90,7 +90,7 @@
 			<key>name</key>
 			<string>String, Symbols, Inherited Class, Markup Heading, GitGutter inserted</string>
 			<key>scope</key>
-			<string>string, constant.other.symbol, entity.other.inherited-class, markup.heading, markup.inserted.git_gutter</string>
+			<string>string, constant.other.symbol, entity.other.inherited-class, entity.name.filename, markup.heading, markup.inserted.git_gutter</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>

--- a/textmate/Tomorrow.tmTheme
+++ b/textmate/Tomorrow.tmTheme
@@ -90,7 +90,7 @@
 			<key>name</key>
 			<string>String, Symbols, Inherited Class, Markup Heading, GitGutter inserted</string>
 			<key>scope</key>
-			<string>string, constant.other.symbol, entity.other.inherited-class, markup.heading, markup.inserted.git_gutter</string>
+			<string>string, constant.other.symbol, entity.other.inherited-class, entity.name.filename, markup.heading, markup.inserted.git_gutter</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>


### PR DESCRIPTION
Tucked it in with the same green color as markup headers.
