### PR TITLE
Add colorSpaceName=sRGB to Textmate themes for proper color matching

### DIFF
--- a/textmate/Tomorrow-Night-Blue.tmTheme
+++ b/textmate/Tomorrow-Night-Blue.tmTheme
@@ -241,5 +241,7 @@
 	</array>
 	<key>uuid</key>
 	<string>3F4BB232-3C3A-4396-99C0-06A9573715E9</string>
+  <key>colorSpaceName</key>
+  <string>sRGB</string>
 </dict>
 </plist>

--- a/textmate/Tomorrow-Night-Bright.tmTheme
+++ b/textmate/Tomorrow-Night-Bright.tmTheme
@@ -241,5 +241,7 @@
 	</array>
 	<key>uuid</key>
 	<string>33D8C715-AD3A-455B-8DF2-56F708909FFE</string>
+  <key>colorSpaceName</key>
+  <string>sRGB</string>
 </dict>
 </plist>

--- a/textmate/Tomorrow-Night-Eighties.tmTheme
+++ b/textmate/Tomorrow-Night-Eighties.tmTheme
@@ -241,5 +241,7 @@
 	</array>
 	<key>uuid</key>
 	<string>DE477E5B-BD4D-46B0-BF80-2EA32A2814D5</string>
+  <key>colorSpaceName</key>
+  <string>sRGB</string>
 </dict>
 </plist>

--- a/textmate/Tomorrow-Night.tmTheme
+++ b/textmate/Tomorrow-Night.tmTheme
@@ -241,5 +241,7 @@
 	</array>
 	<key>uuid</key>
 	<string>F96223EB-1A60-4617-92F3-D24D4F13DB09</string>
+  <key>colorSpaceName</key>
+  <string>sRGB</string>
 </dict>
 </plist>

--- a/textmate/Tomorrow.tmTheme
+++ b/textmate/Tomorrow.tmTheme
@@ -241,5 +241,7 @@
 	</array>
 	<key>uuid</key>
 	<string>82CCD69C-F1B1-4529-B39E-780F91F07604</string>
+  <key>colorSpaceName</key>
+  <string>sRGB</string>
 </dict>
 </plist>


### PR DESCRIPTION
I'd always wondered why cross-application themes like Tomorrow Night (or Solarized, or Monokai) didn't look quite right in Textmate 2 vs Terminal/iTerm/vim/Sublime, then discovered today that Textmate now recommends adding a colorSpaceName = sRGB key/value pair to theme files for better color correctness. See https://github.com/textmate/textmate/blob/master/Applications/TextMate/about/Changes.md#2013-02-18-a9383

Attached are screenshots of master (w/o colorspacename setting):

![tomorrow-night-no-colorspacename](https://f.cloud.github.com/assets/163454/1607936/53f876e0-54b4-11e3-870b-fbd3225a6001.png)

And my pull request (w/colorspacename):

![tomorrow-night-colorspacename-srgb](https://f.cloud.github.com/assets/163454/1607937/62fa0a78-54b4-11e3-94b8-20dbfca30863.png)
