### PR TITLE
Add vim Keyword syntax coloring to Tomorrow-Night-Eighties

### DIFF
--- a/vim/colors/Tomorrow-Night-Eighties.vim
+++ b/vim/colors/Tomorrow-Night-Eighties.vim
@@ -271,6 +271,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Structure", s:purple, "", "")
 	call <SID>X("Function", s:blue, "", "")
 	call <SID>X("Constant", s:orange, "", "")
+	call <SID>X("Keyword", s:orange, "", "")
 	call <SID>X("String", s:green, "", "")
 	call <SID>X("Special", s:foreground, "", "")
 	call <SID>X("PreProc", s:purple, "", "")


### PR DESCRIPTION
Orange might not be the best choice, so I'm open to other suggestions,
but I think something is better than nothing.

Before change (on a Scala file):
![screenshot 2014-01-20 18 36 16 2](https://f.cloud.github.com/assets/977929/1959348/fa264b92-822b-11e3-9ef6-d96613f3a63c.png)

After change:
![screenshot 2014-01-20 18 35 52](https://f.cloud.github.com/assets/977929/1959352/0057934a-822c-11e3-9695-0d1f6ffcfed1.png)
