### PR TITLE
textmate: add gutter & gutterForeground keys

### DIFF
--- a/textmate/Tomorrow-Night-Bright.tmTheme
+++ b/textmate/Tomorrow-Night-Bright.tmTheme
@@ -23,6 +23,10 @@
 				<string>#2A2A2A</string>
 				<key>selection</key>
 				<string>#424242</string>
+				<key>gutter</key>
+				<string>#191919</string>
+				<key>gutterForeground</key>
+				<string>#404040</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Helps distinguish between the gutter and document. Before, they were both black for this Tomorrow Night variant, making it hard to tell where the leading edge of the document was.  Discovered the settings keys from [this comment](http://sublimetext.userecho.com/topic/93504-use-separate-colors-for-the-background-gutter-and-folder-tree/#comment_200133).
#### Tested on
- [x] ST 3
- [x] ST 2
- [ ] Textmate
