### PR TITLE
Fixed color issues when viewing diffs in Vim

### DIFF
--- a/vim/colors/Tomorrow-Night-Blue.vim
+++ b/vim/colors/Tomorrow-Night-Blue.vim
@@ -349,10 +349,10 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("htmlScriptTag", s:red, "", "")
 
 	" Diff Highlighting
-  call <SID>X("diffAdd", "", "4c4e39", "")
-  call <SID>X("diffDelete", s:background, s:red, "")
-  call <SID>X("diffChange", "", "2b5b77", "")
-  call <SID>X("diffText", s:line, s:blue, "")
+	call <SID>X("diffAdd", "", "4c4e39", "")
+	call <SID>X("diffDelete", s:background, s:red, "")
+	call <SID>X("diffChange", "", "2b5b77", "")
+	call <SID>X("diffText", s:line, s:blue, "")
 
 	" ShowMarks Highlighting
 	call <SID>X("ShowMarksHLl", s:orange, s:background, "none")

--- a/vim/colors/Tomorrow-Night-Bright.vim
+++ b/vim/colors/Tomorrow-Night-Bright.vim
@@ -349,10 +349,10 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("htmlScriptTag", s:red, "", "")
 
 	" Diff Highlighting
-  call <SID>X("diffAdd", "", "4c4e39", "")
-  call <SID>X("diffDelete", s:background, s:red, "")
-  call <SID>X("diffChange", "", "2B5B77", "")
-  call <SID>X("diffText", s:line, s:blue, "")
+	call <SID>X("diffAdd", "", "4c4e39", "")
+	call <SID>X("diffDelete", s:background, s:red, "")
+	call <SID>X("diffChange", "", "2B5B77", "")
+	call <SID>X("diffText", s:line, s:blue, "")
 
 	" ShowMarks Highlighting
 	call <SID>X("ShowMarksHLl", s:orange, s:background, "none")

--- a/vim/colors/Tomorrow-Night-Eighties.vim
+++ b/vim/colors/Tomorrow-Night-Eighties.vim
@@ -349,10 +349,10 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("htmlScriptTag", s:red, "", "")
 
 	" Diff Highlighting
-  call <SID>X("diffAdd", "", "4c4e39", "")
-  call <SID>X("diffDelete", s:background, s:red, "")
-  call <SID>X("diffChange", "", "2B5B77", "")
-  call <SID>X("diffText", s:line, s:blue, "")
+	call <SID>X("diffAdd", "", "4c4e39", "")
+	call <SID>X("diffDelete", s:background, s:red, "")
+	call <SID>X("diffChange", "", "2B5B77", "")
+	call <SID>X("diffText", s:line, s:blue, "")
 
 	" ShowMarks Highlighting
 	call <SID>X("ShowMarksHLl", s:orange, s:background, "none")

--- a/vim/colors/Tomorrow-Night.vim
+++ b/vim/colors/Tomorrow-Night.vim
@@ -357,10 +357,10 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("htmlScriptTag", s:red, "", "")
 
 	" Diff Highlighting
-  call <SID>X("diffAdd", "", "4c4e39", "")
-  call <SID>X("diffDelete", s:background, s:red, "")
-  call <SID>X("diffChange", "", "2B5B77", "")
-  call <SID>X("diffText", s:line, s:blue, "")
+	call <SID>X("diffAdd", "", "4c4e39", "")
+	call <SID>X("diffDelete", s:background, s:red, "")
+	call <SID>X("diffChange", "", "2B5B77", "")
+	call <SID>X("diffText", s:line, s:blue, "")
 
 	" ShowMarks Highlighting
 	call <SID>X("ShowMarksHLl", s:orange, s:background, "none")


### PR DESCRIPTION
The default settings for diffs look fine when using Tomorrow. But if you use another theme like Tomorrow-Night, then it looks hideous:

![default](https://cloud.githubusercontent.com/assets/343450/3040936/f8c60d3c-e0ef-11e3-9823-cff31152f648.png)

This pull request fixes the look in each of the alternative schemes.
## Tomorrow-Night

![tomorrow-night](https://cloud.githubusercontent.com/assets/343450/3040978/4733cad6-e0f0-11e3-89b2-8205c57cb52c.png)

---
## Tomorrow-Night-Blue

![blue](https://cloud.githubusercontent.com/assets/343450/3040950/1cdb3a44-e0f0-11e3-9ba1-da3e319cf0da.png)

---
# Tomorrow-Night-Bright

![bright](https://cloud.githubusercontent.com/assets/343450/3040966/2cdfea2a-e0f0-11e3-880d-88b7ced8ff20.png)

---
# Tomorrow-Night-Eighties

![eighties](https://cloud.githubusercontent.com/assets/343450/3040973/3ad94e5a-e0f0-11e3-8acb-9506b16fc327.png)

---

The default Tomorrow theme is left as is, because it looks fine with the default settings

![tomorrow](https://cloud.githubusercontent.com/assets/343450/3040990/6cbe445c-e0f0-11e3-91dd-e372f56a9750.png)
