### PR TITLE
Changed visual whitespace color in the Qt Creator theme.

### DIFF
--- a/QtCreator/styles/Tomorrow-Night-Blue.xml
+++ b/QtCreator/styles/Tomorrow-Night-Blue.xml
@@ -27,7 +27,7 @@
   <style name="Comment" foreground="#7285b7"/>
   <style name="Doxygen.Comment" foreground="#969896"/>
   <style name="Doxygen.Tag" foreground="#7285b7"/>
-  <style name="VisualWhitespace" foreground="#c0c0c0"/>
+  <style name="VisualWhitespace" foreground="#003f8e"/>
   <style name="QmlLocalId" foreground="#bbdaff" italic="true"/>
   <style name="QmlExternalId" foreground="#ffc58f" italic="true"/>
   <style name="QmlTypeId" foreground="#bbdaff"/>

--- a/QtCreator/styles/Tomorrow-Night-Bright.xml
+++ b/QtCreator/styles/Tomorrow-Night-Bright.xml
@@ -27,7 +27,7 @@
   <style name="Comment" foreground="#969896"/>
   <style name="Doxygen.Comment" foreground="#969896"/>
   <style name="Doxygen.Tag" foreground="#969896"/>
-  <style name="VisualWhitespace" foreground="#c0c0c0"/>
+  <style name="VisualWhitespace" foreground="#424242"/>
   <style name="QmlLocalId" foreground="#7aa6da" italic="true"/>
   <style name="QmlExternalId" foreground="#e78c45" italic="true"/>
   <style name="QmlTypeId" foreground="#7aa6da"/>

--- a/QtCreator/styles/Tomorrow-Night-Eighties.xml
+++ b/QtCreator/styles/Tomorrow-Night-Eighties.xml
@@ -27,7 +27,7 @@
   <style name="Comment" foreground="#999999"/>
   <style name="Doxygen.Comment" foreground="#969896"/>
   <style name="Doxygen.Tag" foreground="#999999"/>
-  <style name="VisualWhitespace" foreground="#c0c0c0"/>
+  <style name="VisualWhitespace" foreground="#515151"/>
   <style name="QmlLocalId" foreground="#99cccc" italic="true"/>
   <style name="QmlExternalId" foreground="#f99157" italic="true"/>
   <style name="QmlTypeId" foreground="#99cccc"/>

--- a/QtCreator/styles/Tomorrow-Night.xml
+++ b/QtCreator/styles/Tomorrow-Night.xml
@@ -27,7 +27,7 @@
   <style name="Comment" foreground="#969896"/>
   <style name="Doxygen.Comment" foreground="#969896"/>
   <style name="Doxygen.Tag" foreground="#969896"/>
-  <style name="VisualWhitespace" foreground="#c0c0c0"/>
+  <style name="VisualWhitespace" foreground="#373b41"/>
   <style name="QmlLocalId" foreground="#81a2be" italic="true"/>
   <style name="QmlExternalId" foreground="#de935f" italic="true"/>
   <style name="QmlTypeId" foreground="#81a2be"/>


### PR DESCRIPTION
Visual whitespace is off by default in Qt Creator, but I prefer having it on, so that I can see indentation. However, it shouldn't be "too visual" or it just gets in the way.

In Tomorrow, the visual whitespace is quite close to the background color, which means you can see it, but not too much. In all other variations, it was the same color as the text, which made it too visible.

I set the visual whitespace color to match the "line number" color (the same as "disabled code"), which means it's quite close to the background color.

Tomorrow didn't have the visual whitespace color set, but the default set by Qt Creator worked, so I didn't change that (although it's not in the theme's color palette).
