### PR TITLE
Add "Xcode" directory

### DIFF
--- a/Xcode/Tomorrow Night Bright.dvtcolortheme
+++ b/Xcode/Tomorrow Night Bright.dvtcolortheme
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>0.897185 0.897357 0.897156 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>Menlo-Bold - 11.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>0.897185 0.897357 0.897156 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.409739 0.571471 0.844841 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>0.897185 0.897357 0.897156 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>0.897185 0.897357 0.897156 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0 0 0 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>0.897185 0.897357 0.897156 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.198543 0.198582 0.198537 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.674115 0.76923 0.0847647 1</string>
+	<key>DVTSourceTextBackground</key>
+	<string>0 0 0 1</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.897185 0.897357 0.897156 1</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.198543 0.198582 0.198537 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.198543 0.198582 0.198537 1</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.869861 0.478962 0.146381 1</string>
+		<key>xcode.syntax.character</key>
+		<string>0.869861 0.478962 0.146381 1</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.517317 0.52609 0.516067 1</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.517317 0.52609 0.516067 1</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.705922 0.496111 0.83689 1</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.878132 0.741812 0.0564746 1</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.878132 0.741812 0.0564746 1</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.897185 0.897357 0.897156 1</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.897185 0.897357 0.897156 1</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.878132 0.741812 0.0564746 1</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.409739 0.571471 0.844841 1</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.38239 0.708845 0.628655 1</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.38239 0.708845 0.628655 1</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.781264 0.221137 0.248336 1</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.869861 0.478962 0.146381 1</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.781264 0.221137 0.248336 1</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.781264 0.221137 0.248336 1</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.705922 0.496111 0.83689 1</string>
+		<key>xcode.syntax.number</key>
+		<string>0.869861 0.478962 0.146381 1</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.897185 0.897357 0.897156 1</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.781264 0.221137 0.248336 1</string>
+		<key>xcode.syntax.string</key>
+		<string>0.674115 0.76923 0.0847647 1</string>
+		<key>xcode.syntax.url</key>
+		<string>0.409739 0.571471 0.844841 1</string>
+	</dict>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.character</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.number</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.string</key>
+		<string>Menlo-Regular - 14.0</string>
+		<key>xcode.syntax.url</key>
+		<string>Menlo-Regular - 14.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Xcode/Tomorrow Night Eighties.dvtcolortheme
+++ b/Xcode/Tomorrow Night Eighties.dvtcolortheme
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.506524 0.633807 0.747343 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0.112404 0.120126 0.130254 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.216386 0.231364 0.2553 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.708155 0.741288 0.405974 1</string>
+	<key>DVTSourceTextBackground</key>
+	<string>0.176471 0.176471 0.176471 1</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.293494 0.306201 0.33183 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.317647 0.317647 0.317647 1</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.976471 0.568627 0.341176 1</string>
+		<key>xcode.syntax.character</key>
+		<string>0.976471 0.568627 0.341176 1</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.6 0.6 0.6 1</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.6 0.6 0.6 1</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.8 0.6 0.8 1</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>1 0.8 0.4 1</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>1 0.8 0.4 1</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.8 0.8 0.8 1</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.8 0.8 0.8 1</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>1 0.8 0.4 1</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.4 0.6 0.8 1</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.4 0.8 0.8 1</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.4 0.8 0.8 1</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.94902 0.466667 0.439216 1</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.976471 0.568627 0.341176 1</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.94902 0.466667 0.439216 1</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.94902 0.466667 0.439216 1</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.8 0.6 0.8 1</string>
+		<key>xcode.syntax.number</key>
+		<string>0.976471 0.568627 0.341176 1</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.8 0.8 0.8 1</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.94902 0.466667 0.439216 1</string>
+		<key>xcode.syntax.string</key>
+		<string>0.6 0.8 0.6 1</string>
+		<key>xcode.syntax.url</key>
+		<string>0.4 0.6 0.8 1</string>
+	</dict>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.character</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.number</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.string</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.url</key>
+		<string>Menlo-Regular - 12.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Xcode/Tomorrow Night.dvtcolortheme
+++ b/Xcode/Tomorrow Night.dvtcolortheme
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.506524 0.633807 0.747343 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>Menlo-Bold - 12.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0.112404 0.120126 0.130254 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.216386 0.231364 0.2553 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.708155 0.741288 0.405974 1</string>
+	<key>DVTSourceTextBackground</key>
+	<string>0.112404 0.120126 0.130254 1</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.770437 0.783913 0.778299 1</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.293494 0.306201 0.33183 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.216386 0.231364 0.2553 1</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.868731 0.575814 0.373674 1</string>
+		<key>xcode.syntax.character</key>
+		<string>0.868731 0.575814 0.373674 1</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.589928 0.594322 0.589154 1</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.589928 0.594322 0.589154 1</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.696639 0.58008 0.734811 1</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.939447 0.774972 0.455114 1</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.939447 0.774972 0.455114 1</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.770437 0.783913 0.778299 1</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.770437 0.783913 0.778299 1</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.939447 0.774972 0.455114 1</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.506524 0.633807 0.747343 1</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.550924 0.745364 0.717924 1</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.550924 0.745364 0.717924 1</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.801655 0.399344 0.401992 1</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.868731 0.575814 0.373674 1</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.801655 0.399344 0.401992 1</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.801655 0.399344 0.401992 1</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.696639 0.58008 0.734811 1</string>
+		<key>xcode.syntax.number</key>
+		<string>0.868731 0.575814 0.373674 1</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.770437 0.783913 0.778299 1</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.801655 0.399344 0.401992 1</string>
+		<key>xcode.syntax.string</key>
+		<string>0.708155 0.741288 0.405974 1</string>
+		<key>xcode.syntax.url</key>
+		<string>0.506524 0.633807 0.747343 1</string>
+	</dict>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.character</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.number</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.string</key>
+		<string>Menlo-Regular - 12.0</string>
+		<key>xcode.syntax.url</key>
+		<string>Menlo-Regular - 12.0</string>
+	</dict>
+</dict>
+</plist>

--- a/Xcode/Tomorrow.dvtcolortheme
+++ b/Xcode/Tomorrow.dvtcolortheme
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>0.793012 0.152623 0.143433 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>Consolas - 12.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>0.793012 0.152623 0.143433 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>Consolas - 12.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.303557 0.303796 0.299714 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>Consolas - 12.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>0.303557 0.303796 0.299714 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>Consolas - 12.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>0.303557 0.303796 0.299714 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>Consolas - 12.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0.999873 1 0.999841 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>0.303557 0.303796 0.299714 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.83978 0.839941 0.839753 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.971483 0.530718 0.0375477 1</string>
+	<key>DVTSourceTextBackground</key>
+	<string>0.999873 1 0.999841 1</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.303557 0.303796 0.299714 1</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.935976 0.936156 0.935946 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.83978 0.839941 0.839753 1</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.971483 0.530718 0.0375477 1</string>
+		<key>xcode.syntax.character</key>
+		<string>0.971483 0.530718 0.0375477 1</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.555162 0.564683 0.5504 1</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.555162 0.564683 0.5504 1</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.540796 0.340821 0.667724 0.8</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.22806 0.598894 0.628281 1</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.22806 0.598894 0.628281 1</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.923358 0.725624 0 1</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.923358 0.725624 0 1</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.25043 0.439404 0.691119 1</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.25043 0.439404 0.691119 1</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.540796 0.340821 0.667724 1</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.540796 0.340821 0.667724 1</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.793012 0.152623 0.143433 1</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.971483 0.530718 0.0375477 1</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.793012 0.152623 0.143433 1</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.793012 0.152623 0.143433 1</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.540796 0.340821 0.667724 1</string>
+		<key>xcode.syntax.number</key>
+		<string>0.971483 0.530718 0.0375477 1</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.303557 0.303796 0.299714 1</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.793012 0.152623 0.143433 1</string>
+		<key>xcode.syntax.string</key>
+		<string>0.440623 0.556631 0 1</string>
+		<key>xcode.syntax.url</key>
+		<string>0.25043 0.439404 0.691119 1</string>
+	</dict>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.character</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.number</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.string</key>
+		<string>Consolas - 12.0</string>
+		<key>xcode.syntax.url</key>
+		<string>Consolas - 12.0</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Create an "Xcode" directory and copy the current contents of the
"Xcode 4" directory to it.

Previously, the "Xcode 4" directory was the only Xcode-related
directory in the repo, which is misleading because the themes
contained in it also work fine in Xcode 6 (beta 5).

Other projects (e.g., Alcatraz) use URLs that link directly to the
existing themes in the "Xcode 4" directory, so instead of removing the
"Xcode 4" directory and breaking everything that might be linking to
those themes, I propose we leave it for now.

Moving forward, instead of supporting each version of Xcode by creating
an separate "Xcode <version>" directory -- which wasn't done for
Xcode 5 or Xcode 6 -- I propose there be a single "Xcode" directory
that supports the latest version of Xcode.
