### PR TITLE
Correct colors in Tomorrow Night Eighties Xcode

### DIFF
--- a/Xcode 4/Tomorrow Night Eighties.dvtcolortheme
+++ b/Xcode 4/Tomorrow Night Eighties.dvtcolortheme
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>DVTConsoleDebuggerInputTextColor</key>
-	<string>0.770437 0.783913 0.778299 1</string>
+	<string>0.755591 0.755568 0.755581 1</string>
 	<key>DVTConsoleDebuggerInputTextFont</key>
 	<string>Menlo-Bold - 12.0</string>
 	<key>DVTConsoleDebuggerOutputTextColor</key>
-	<string>0.770437 0.783913 0.778299 1</string>
+	<string>0.755591 0.755568 0.755581 1</string>
 	<key>DVTConsoleDebuggerOutputTextFont</key>
 	<string>Menlo-Bold - 12.0</string>
 	<key>DVTConsoleDebuggerPromptTextColor</key>
@@ -15,79 +15,79 @@
 	<key>DVTConsoleDebuggerPromptTextFont</key>
 	<string>Menlo-Bold - 12.0</string>
 	<key>DVTConsoleExectuableInputTextColor</key>
-	<string>0.770437 0.783913 0.778299 1</string>
+	<string>0.755591 0.755568 0.755581 1</string>
 	<key>DVTConsoleExectuableInputTextFont</key>
 	<string>Menlo-Bold - 12.0</string>
 	<key>DVTConsoleExectuableOutputTextColor</key>
-	<string>0.770437 0.783913 0.778299 1</string>
+	<string>0.755591 0.755568 0.755581 1</string>
 	<key>DVTConsoleExectuableOutputTextFont</key>
 	<string>Menlo-Bold - 12.0</string>
 	<key>DVTConsoleTextBackgroundColor</key>
-	<string>0.112404 0.120126 0.130254 1</string>
+	<string>0.13233 0.132326 0.132329 1</string>
 	<key>DVTConsoleTextInsertionPointColor</key>
 	<string>0.770437 0.783913 0.778299 1</string>
 	<key>DVTConsoleTextSelectionColor</key>
-	<string>0.216386 0.231364 0.2553 1</string>
+	<string>0.249687 0.249679 0.249683 1</string>
 	<key>DVTDebuggerInstructionPointerColor</key>
 	<string>0.708155 0.741288 0.405974 1</string>
 	<key>DVTSourceTextBackground</key>
-	<string>0.176471 0.176471 0.176471 1</string>
+	<string>0.13233 0.132326 0.132329 1</string>
 	<key>DVTSourceTextBlockDimBackgroundColor</key>
 	<string>0.5 0.5 0.5 1</string>
 	<key>DVTSourceTextInsertionPointColor</key>
-	<string>0.770437 0.783913 0.778299 1</string>
+	<string>0.755591 0.755568 0.755581 1</string>
 	<key>DVTSourceTextInvisiblesColor</key>
-	<string>0.293494 0.306201 0.33183 1</string>
+	<string>0.249687 0.249679 0.249683 1</string>
 	<key>DVTSourceTextSelectionColor</key>
-	<string>0.317647 0.317647 0.317647 1</string>
+	<string>0.249687 0.249679 0.249683 1</string>
 	<key>DVTSourceTextSyntaxColors</key>
 	<dict>
 		<key>xcode.syntax.attribute</key>
-		<string>0.976471 0.568627 0.341176 1</string>
+		<string>0.961064 0.489363 0.27364 1</string>
 		<key>xcode.syntax.character</key>
-		<string>0.976471 0.568627 0.341176 1</string>
+		<string>0.961064 0.489363 0.27364 1</string>
 		<key>xcode.syntax.comment</key>
-		<string>0.6 0.6 0.6 1</string>
+		<string>0.529648 0.529632 0.529641 1</string>
 		<key>xcode.syntax.comment.doc</key>
-		<string>0.6 0.6 0.6 1</string>
+		<string>0.529648 0.529632 0.529641 1</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>0.8 0.6 0.8 1</string>
+		<string>0.750159 0.515181 0.755272 1</string>
 		<key>xcode.syntax.identifier.class</key>
-		<string>1 0.8 0.4 1</string>
+		<string>0.99502 0.761244 0.328821 1</string>
 		<key>xcode.syntax.identifier.class.system</key>
-		<string>1 0.8 0.4 1</string>
+		<string>0.99502 0.761244 0.328821 1</string>
 		<key>xcode.syntax.identifier.constant</key>
-		<string>0.8 0.8 0.8 1</string>
+		<string>0.755591 0.755568 0.755581 1</string>
 		<key>xcode.syntax.identifier.constant.system</key>
-		<string>0.8 0.8 0.8 1</string>
+		<string>0.755591 0.755568 0.755581 1</string>
 		<key>xcode.syntax.identifier.function</key>
-		<string>1 0.8 0.4 1</string>
+		<string>0.99502 0.761244 0.328821 1</string>
 		<key>xcode.syntax.identifier.function.system</key>
-		<string>0.4 0.6 0.8 1</string>
+		<string>0.331338 0.524022 0.75472 1</string>
 		<key>xcode.syntax.identifier.macro</key>
-		<string>0.4 0.8 0.8 1</string>
+		<string>0.341683 0.762099 0.755029 1</string>
 		<key>xcode.syntax.identifier.macro.system</key>
-		<string>0.4 0.8 0.8 1</string>
+		<string>0.341683 0.762099 0.755029 1</string>
 		<key>xcode.syntax.identifier.type</key>
-		<string>0.94902 0.466667 0.439216 1</string>
+		<string>0.925674 0.373705 0.404131 1</string>
 		<key>xcode.syntax.identifier.type.system</key>
-		<string>0.976471 0.568627 0.341176 1</string>
+		<string>0.961064 0.489363 0.27364 1</string>
 		<key>xcode.syntax.identifier.variable</key>
-		<string>0.94902 0.466667 0.439216 1</string>
+		<string>0.925674 0.373705 0.404131 1</string>
 		<key>xcode.syntax.identifier.variable.system</key>
-		<string>0.94902 0.466667 0.439216 1</string>
+		<string>0.925674 0.373705 0.404131 1</string>
 		<key>xcode.syntax.keyword</key>
-		<string>0.8 0.6 0.8 1</string>
+		<string>0.750159 0.515181 0.755272 1</string>
 		<key>xcode.syntax.number</key>
-		<string>0.976471 0.568627 0.341176 1</string>
+		<string>0.961064 0.489363 0.27364 1</string>
 		<key>xcode.syntax.plain</key>
-		<string>0.8 0.8 0.8 1</string>
+		<string>0.755591 0.755568 0.755581 1</string>
 		<key>xcode.syntax.preprocessor</key>
-		<string>0.94902 0.466667 0.439216 1</string>
+		<string>0.925674 0.373705 0.404131 1</string>
 		<key>xcode.syntax.string</key>
-		<string>0.6 0.8 0.6 1</string>
+		<string>0.536806 0.766265 0.530051 1</string>
 		<key>xcode.syntax.url</key>
-		<string>0.4 0.6 0.8 1</string>
+		<string>0.331338 0.524022 0.75472 1</string>
 	</dict>
 	<key>DVTSourceTextSyntaxFonts</key>
 	<dict>


### PR DESCRIPTION
Colors weren't set properly. Noticed that the colors looked a bit off
compared to Sublime Text and Terminal versions of the Tomorrow Night
Eighties theme I had.

I used Skala Color (http://bjango.com/mac/skalacolor/) to view the hex
codes for the colors in the Xcode theme, confirmed they were a bit off,
and then manually entered the correct hex colors.
