### PR TITLE
Add colour support for keywords 'for', 'range', 'case' and 'default' in Golang.

### DIFF
--- a/vim/colors/Tomorrow-Night-Blue.vim
+++ b/vim/colors/Tomorrow-Night-Blue.vim
@@ -398,6 +398,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
 	call <SID>X("goRepeat", s:purple, "", "")
+	call <SID>X("goLabel", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow-Night-Blue.vim
+++ b/vim/colors/Tomorrow-Night-Blue.vim
@@ -397,6 +397,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goTodo", s:yellow, "", "")
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
+	call <SID>X("goRepeat", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow-Night-Bright.vim
+++ b/vim/colors/Tomorrow-Night-Bright.vim
@@ -398,6 +398,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
 	call <SID>X("goRepeat", s:purple, "", "")
+	call <SID>X("goLabel", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow-Night-Bright.vim
+++ b/vim/colors/Tomorrow-Night-Bright.vim
@@ -397,6 +397,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goTodo", s:yellow, "", "")
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
+	call <SID>X("goRepeat", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow-Night-Eighties.vim
+++ b/vim/colors/Tomorrow-Night-Eighties.vim
@@ -398,6 +398,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
 	call <SID>X("goRepeat", s:purple, "", "")
+	call <SID>X("goLabel", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow-Night-Eighties.vim
+++ b/vim/colors/Tomorrow-Night-Eighties.vim
@@ -397,6 +397,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goTodo", s:yellow, "", "")
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
+	call <SID>X("goRepeat", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow-Night.vim
+++ b/vim/colors/Tomorrow-Night.vim
@@ -405,6 +405,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goTodo", s:yellow, "", "")
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
+	call <SID>X("goRepeat", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow-Night.vim
+++ b/vim/colors/Tomorrow-Night.vim
@@ -406,6 +406,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
 	call <SID>X("goRepeat", s:purple, "", "")
+	call <SID>X("goLabel", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow.vim
+++ b/vim/colors/Tomorrow.vim
@@ -392,6 +392,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goTodo", s:yellow, "", "")
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
+	call <SID>X("goRepeat", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")

--- a/vim/colors/Tomorrow.vim
+++ b/vim/colors/Tomorrow.vim
@@ -393,6 +393,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("goDeclType", s:blue, "", "")
 	call <SID>X("goBuiltins", s:purple, "", "")
 	call <SID>X("goRepeat", s:purple, "", "")
+	call <SID>X("goLabel", s:purple, "", "")
 
 	" Clojure Highlighting
 	call <SID>X("clojureConstant", s:orange, "", "")


### PR DESCRIPTION
The loop keyword `for`, the builtin function `range` as well as the control flow keywords `case` and `default` for the Go programming language lack colour in this theme in Vim. This is fixed by adding a declaration for `goRepeat` and `goLabel` to the Go section in the theme.

See [this line](https://github.com/fatih/vim-go/blob/master/syntax/go.vim#L87) in the Go syntax file for Vim.