### PR TITLE
vim: highlight Rust conditional keywords

### DIFF
--- a/vim/colors/Tomorrow-Night-Blue.vim
+++ b/vim/colors/Tomorrow-Night-Blue.vim
@@ -474,6 +474,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("diffRemoved", s:red, "", "")
 	call <SID>X("gitcommitSummary", "", "", "bold")
 
+	" Rust
+	call <SID>X("rustConditional", s:orange, "", "")
+
 	" Delete Functions
 	delf <SID>X
 	delf <SID>rgb

--- a/vim/colors/Tomorrow-Night-Bright.vim
+++ b/vim/colors/Tomorrow-Night-Bright.vim
@@ -474,6 +474,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("diffRemoved", s:red, "", "")
 	call <SID>X("gitcommitSummary", "", "", "bold")
 
+	" Rust
+	call <SID>X("rustConditional", s:orange, "", "")
+
 	" Delete Functions
 	delf <SID>X
 	delf <SID>rgb

--- a/vim/colors/Tomorrow-Night-Eighties.vim
+++ b/vim/colors/Tomorrow-Night-Eighties.vim
@@ -474,6 +474,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("diffRemoved", s:red, "", "")
 	call <SID>X("gitcommitSummary", "", "", "bold")
 
+	" Rust
+	call <SID>X("rustConditional", s:orange, "", "")
+
 	" Delete Functions
 	delf <SID>X
 	delf <SID>rgb

--- a/vim/colors/Tomorrow-Night.vim
+++ b/vim/colors/Tomorrow-Night.vim
@@ -482,6 +482,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("diffRemoved", s:red, "", "")
 	call <SID>X("gitcommitSummary", "", "", "bold")
 
+	" Rust
+	call <SID>X("rustConditional", s:orange, "", "")
+
 	" Delete Functions
 	delf <SID>X
 	delf <SID>rgb

--- a/vim/colors/Tomorrow.vim
+++ b/vim/colors/Tomorrow.vim
@@ -469,6 +469,9 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("diffRemoved", s:red, "", "")
 	call <SID>X("gitcommitSummary", "", "", "bold")
 
+	" Rust
+	call <SID>X("rustConditional", s:orange, "", "")
+
 	" Delete Functions
 	delf <SID>X
 	delf <SID>rgb


### PR DESCRIPTION
By default Tomorrow and its variants [do not have](https://github.com/chriskempson/tomorrow-theme/blob/master/vim/colors/Tomorrow.vim#L272) any particular highlighting for `Conditional`. When programming in Rust, it is really confusing since [Rust conditionals](https://github.com/rust-lang/rust.vim/blob/master/syntax/rust.vim#L16), such as the ubiquitous `match`, do not stand out in the code. I propose highlighting them as other keywords, that is, with `orange`. Thank you.

Ivan