### PR TITLE
Update the mate-terminal script to use GSettings as gconftool

### DIFF
--- a/Mate-Terminal/setup-theme.sh
+++ b/Mate-Terminal/setup-theme.sh
@@ -1,44 +1,42 @@
 #!/usr/bin/env bash
 
 [[ -z "$PROFILE_NAME" ]] && PROFILE_NAME=Tomorrow
-[[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG=Tomorrow
-[[ -z "$GCONFTOOL" ]] && GCONFTOOL=mateconftool-2
-[[ -z "$BASE_KEY" ]] && BASE_KEY=/apps/mate-terminal/profiles
+[[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG=tomorrow
+[[ -z "$GCONFTOOL" ]] && GCONFTOOL=gsettings
+[[ -z "$BASE_SCHEMA" ]] && BASE_SCHEMA=org.mate.terminal.profile:/org/mate/terminal/profiles
 
-PROFILE_KEY="$BASE_KEY/$PROFILE_SLUG"
+PROFILE_SCHEMA="$BASE_SCHEMA/$PROFILE_SLUG/"
 
 gset() {
-  local type="$1"; shift
   local key="$1"; shift
   local val="$1"; shift
 
-  "$GCONFTOOL" --set --type "$type" "$PROFILE_KEY/$key" -- "$val"
+  "$GCONFTOOL" set "$PROFILE_SCHEMA" "$key" "$val"
 }
 
 # because gconftool doesn't have "append"
 glist_append() {
-  local type="$1"; shift
+  local schema="$1"; shift
   local key="$1"; shift
   local val="$1"; shift
 
   local entries="$(
     {
-      "$GCONFTOOL" --get "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
-      echo "$val"
+      "$GCONFTOOL" get "$schema" "$key" | tr -d '[]' | tr , "\n" | fgrep -v "$val"
+      echo " '$val'"
     } | head -c-1 | tr "\n" ,
   )"
 
-  "$GCONFTOOL" --set --type list --list-type $type "$key" "[$entries]"
+  "$GCONFTOOL" set "$schema" "$key" "[$entries]"
 }
 
 # append the Tomorrow profile to the profile list
-glist_append string /apps/mate-terminal/global/profile_list "$PROFILE_SLUG"
+glist_append org.mate.terminal.global profile-list "$PROFILE_SLUG"
 
-gset string visible_name "$PROFILE_NAME"
-gset string palette "#000000000000:#919122222626:#777789890000:#AEAE7B7B0000:#1D1D25259494:#68682a2a9b9b:#2B2B66665151:#929295959393:#666666666666:#CCCC66666666:#B5B5BDBD6868:#F0F0C6C67474:#8181A2A2BEBE:#B2B29494BBBB:#8A8ABEBEB7B7:#ECECEBEBECEC"
-gset string background_color "#1d1d1f1f2121"
-gset string foreground_color "#c5c5c8c8c6c6"
-gset string bold_color "#8A8ABEBEB7B7"
-gset bool   bold_color_same_as_fg "false"
-gset bool   use_theme_colors "false"
-gset bool   use_theme_background "false"
+gset visible-name "$PROFILE_NAME"
+gset palette "#000000000000:#919122222626:#777789890000:#AEAE7B7B0000:#1D1D25259494:#68682a2a9b9b:#2B2B66665151:#929295959393:#666666666666:#CCCC66666666:#B5B5BDBD6868:#F0F0C6C67474:#8181A2A2BEBE:#B2B29494BBBB:#8A8ABEBEB7B7:#ECECEBEBECEC"
+gset background-color "#1d1d1f1f2121"
+gset foreground-color "#c5c5c8c8c6c6"
+gset bold-color "#8A8ABEBEB7B7"
+gset bold-color-same-as-fg "false"
+gset use-theme-colors "false"


### PR DESCRIPTION
MATE Desktop has started using `GSettings` instead of `mateconftool-2` a while back. This changes the script to work *only* with `GSettings`. Let me know if compatibility with `mateconftool-2` should also be kept.

Tested on Linux Mint 17.3.