### PR TITLE
Add colors for Error and SpellBad in vim

### DIFF
--- a/vim/colors/Tomorrow-Night.vim
+++ b/vim/colors/Tomorrow-Night.vim
@@ -289,6 +289,8 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("Type", s:blue, "", "none")
 	call <SID>X("Define", s:purple, "", "none")
 	call <SID>X("Include", s:blue, "", "")
+	call <SID>X("SpellBad", s:foreground, s:red, "")
+	call <SID>X("Error", s:foreground, s:red, "")
 	"call <SID>X("Ignore", "666666", "", "")
 
 	" Vim Highlighting


### PR DESCRIPTION
Right now the default vim colors make errors unreadable, this fixes it.