### PR TITLE
docs: Add hex color table for all themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,89 @@ A theme should aid your work by providing easily identifiable colours that add m
 ### Tomorrow Night
 ![Tomorrow Night](Images/Tomorrow-Night-Palette.png)
 
+| Color        | Hex       | RGB                  |
+|--------------|-----------|----------------------|
+| Foreground   | `#c5c8c6` | `rgb(197, 200, 198)` |
+| Background   | `#1d1f21` | `rgb(29, 31, 33)`    |
+| Selection    | `#373b41` | `rgb(55, 59, 65)`    |
+| Current line | `#282a2e` | `rgb(40, 42, 46)`    |
+| Comment      | `#969896` | `rgb(150, 152, 150)` |
+| Red          | `#cc6666` | `rgb(204, 102, 102)` |
+| Orange       | `#de935f` | `rgb(222, 147, 95)`  |
+| Yellow       | `#f0c674` | `rgb(240, 198, 116)` |
+| Green        | `#b5bd68` | `rgb(181, 189, 104)` |
+| Aqua         | `#8abeb7` | `rgb(138, 190, 183)` |
+| Blue         | `#81a2be` | `rgb(129, 162, 190)` |
+| Purple       | `#b294bb` | `rgb(178, 148, 187)` |
+
 ### Tomorrow
 ![Tomorrow](Images/Tomorrow-Palette.png)
+
+| Color        | Hex       | RBG                  |
+|--------------|-----------|----------------------|
+| Foreground   | `#4d4d4c` | `rgb(77, 77, 76)`    |
+| Background   | `#ffffff` | `rgb(255, 255, 255)` |
+| Selection    | `#d6d6d6` | `rgb(214, 214, 214)` |
+| Current line | `#efefef` | `rgb(239, 239, 239)` |
+| Comment      | `#8e908c` | `rgb(142, 144, 140)` |
+| Red          | `#c82829` | `rgb(200, 40, 41)`   |
+| Orange       | `#f5871f` | `rgb(245, 135, 31)`  |
+| Yellow       | `#eab700` | `rgb(234, 183, 0)`   |
+| Green        | `#718c00` | `rgb(113, 140, 0)`   |
+| Aqua         | `#3e999f` | `rgb(62, 153, 159)`  |
+| Blue         | `#4271ae` | `rgb(66, 113, 174)`  |
+| Purple       | `#8959a8` | `rgb(137, 89, 168)`  |
 
 ### Tomorrow Night Eighties
 ![Tomorrow Night Eighties](Images/Tomorrow-Night-Eighties-Palette.png)
 
+| Color        | Hex       | RGB                  |
+|--------------|-----------|----------------------|
+| Foreground   | `#cccccc` | `rgb(204, 204, 204)` |
+| Background   | `#2d2d2d` | `rgb(45, 45, 45)`    |
+| Selection    | `#515151` | `rgb(81, 81, 81)`    |
+| Current line | `#393939` | `rgb(57, 57, 57)`    |
+| Comment      | `#999999` | `rgb(153, 153, 153)` |
+| Red          | `#f2777a` | `rgb(242, 119, 122)` |
+| Orange       | `#f99157` | `rgb(249, 145, 87)`  |
+| Yellow       | `#ffcc66` | `rgb(255, 204, 102)` |
+| Green        | `#99cc99` | `rgb(153, 204, 153)` |
+| Aqua         | `#66cccc` | `rgb(102, 204, 204)` |
+| Blue         | `#6699cc` | `rgb(102, 153, 204)` |
+| Purple       | `#cc99cc` | `rgb(204, 153, 204)` |
+
 ### Tomorrow Night Blue
 ![Tomorrow Night Blue](Images/Tomorrow-Night-Blue-Palette.png)
 
+| Color        | Hex       | RGB                  |
+|--------------|-----------|----------------------|
+| Foreground   | `#ffffff` | `rgb(255, 255, 255)` |
+| Background   | `#002451` | `rgb(0, 36, 81)`     |
+| Selection    | `#003f8e` | `rgb(0, 63, 142)`    |
+| Current line | `#00346e` | `rgb(0, 52, 110)`    |
+| Comment      | `#7285b7` | `rgb(114, 133, 183)` |
+| Red          | `#ff9da4` | `rgb(255, 157, 164)` |
+| Orange       | `#ffc58f` | `rgb(255, 197, 143)` |
+| Yellow       | `#ffeead` | `rgb(255, 238, 173)` |
+| Green        | `#d1f1a9` | `rgb(209, 241, 169)` |
+| Aqua         | `#99ffff` | `rgb(153, 255, 255)` |
+| Blue         | `#bbdaff` | `rgb(187, 218, 255)` |
+| Purple       | `#ebbbff` | `rgb(235, 187, 255)` |
+
 ### Tomorrow Night Bright
 ![Tomorrow Night Bright](Images/Tomorrow-Night-Bright-Palette.png)
+
+| Color        | Hex       | RGB                  |
+|--------------|-----------|----------------------|
+| Foreground   | `#eaeaea` | `rgb(234, 234, 234)` |
+| Background   | `#000000` | `rgb(0, 0, 0)`       |
+| Selection    | `#424242` | `rgb(66, 66, 66)`    |
+| Current line | `#2a2a2a` | `rgb(42, 42, 42)`    |
+| Comment      | `#969896` | `rgb(150, 152, 150)` |
+| Red          | `#d54e53` | `rgb(213, 78, 83)`   |
+| Orange       | `#e78c45` | `rgb(231, 140, 69)`  |
+| Yellow       | `#e7c547` | `rgb(231, 197, 71)`  |
+| Green        | `#b9ca4a` | `rgb(185, 202, 74)`  |
+| Aqua         | `#70c0b1` | `rgb(112, 192, 177)` |
+| Blue         | `#7aa6da` | `rgb(122, 166, 218)` |
+| Purple       | `#c397d8` | `rgb(195, 151, 216)` |


### PR DESCRIPTION
**What?**

1. Add lists of hex and rgb values for colors in all themes to README.md

I pulled these values from vim/colors/*

**Why?**

Explicit lists make it easier for contributors to apply the theme in new programs.